### PR TITLE
Kaocha testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,7 @@ jobs:
             - clojure-v1-dependencies-
 
       - run: clojure -Spath
-      - run: mkdir -p test-results/kaocha
-      - run: bin/kaocha --plugin cloverage --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml --cov-output test-results/coverage
+      - run: bin/ci
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,9 @@ jobs:
       - run: clojure -Spath
       - run: bin/ci
       - store_test_results:
-          path: test-results
+          path: test-results/kaocha
+      - store_artifacts:
+          path: test-results/coverage
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
       - run: clojure -Spath
       - run: mkdir -p test-results/kaocha
-      - run: bin/kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+      - run: bin/kaocha --plugin cloverage --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
       - run: clojure -Spath
       - run: mkdir -p test-results/kaocha
-      - run: clojure -Akaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+      - run: bin/kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
 
       - run: clojure -Spath
       - run: mkdir -p test-results/kaocha
-      - run: bin/kaocha --plugin cloverage --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+      - run: bin/kaocha --plugin cloverage --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml --cov-output test-results/coverage
       - store_test_results:
           path: test-results
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,10 @@ jobs:
             - clojure-v1-dependencies-
 
       - run: clojure -Spath
-      - run: clojure -Atest
+      - run: mkdir -p test-results/kaocha
+      - run: clojure -Akaocha --plugin kaocha.plugin/junit-xml --junit-xml-file test-results/kaocha/results.xml
+      - store_test_results:
+          path: test-results
 
       - save_cache:
           paths:

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ then delete the `old-` prefixed tree.
         --credentials resources/role.edn
         [--plan]
 
+# Testing
+
+    bin/kaocha # basic unit tests
+    bin/kaocha --plugin cloverage # with coverage output

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+mkdir -p test-results/{kaocha,coverage}
+bin/kaocha --plugin cloverage \
+           --cov-output test-results/coverage \
+           --plugin kaocha.plugin/junit-xml \
+           --junit-xml-file test-results/kaocha/results.xml
+

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clj -A:kaocha -m kaocha.runner --config-file test/tests.edn "$@"
+clojure -A:kaocha -m kaocha.runner --config-file test/tests.edn "$@"

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+clj -A:kaocha -m kaocha.runner --config-file test/tests.edn "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -36,8 +36,7 @@
          :main-opts ["-m" "cognitect.test-runner" "--exclude" ":aws"]}
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}
-                        lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}}
-           :main-opts ["-m" "kaocha.runner" "--config-file test/tests.edn"]}
+                        lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}}}
   ;; clj -Acoverage
   :coverage {:extra-deps {cloverage {:mvn/version "RELEASE"}}
              :main-opts ["-m" "cloverage.coverage" "-p" "src"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -34,6 +34,9 @@
          :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
                                                  :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
          :main-opts ["-m" "cognitect.test-runner" "--exclude" ":aws"]}
+  :kaocha {:extra-paths ["test"]
+           :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}}
+           :main-opts ["-m" "kaocha.runner" "--config-file test/tests.edn"]}
   ;; clj -Acoverage
   :coverage {:extra-deps {cloverage {:mvn/version "RELEASE"}}
              :main-opts ["-m" "cloverage.coverage" "-p" "src"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,8 @@
          :main-opts ["-m" "cognitect.test-runner" "--exclude" ":aws"]}
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}
-                        lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}}}
+                        lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
+                        lambdaisland/kaocha-cloverage {:mvn/version "0.0-41"}}}
   ;; clj -Acoverage
   :coverage {:extra-deps {cloverage {:mvn/version "RELEASE"}}
              :main-opts ["-m" "cloverage.coverage" "-p" "src"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -35,7 +35,8 @@
                                                  :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
          :main-opts ["-m" "cognitect.test-runner" "--exclude" ":aws"]}
   :kaocha {:extra-paths ["test"]
-           :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}}
+           :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}
+                        lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}}
            :main-opts ["-m" "kaocha.runner" "--config-file test/tests.edn"]}
   ;; clj -Acoverage
   :coverage {:extra-deps {cloverage {:mvn/version "RELEASE"}}

--- a/test/tests.edn
+++ b/test/tests.edn
@@ -1,0 +1,16 @@
+{:kaocha/tests                       [{:kaocha.testable/type :kaocha.type/clojure.test
+                                       :kaocha.testable/id   :unit
+                                       :kaocha/ns-patterns   ["-test$"]
+                                       :kaocha/source-paths  ["src"]
+                                       :kaocha/test-paths    ["test"]}]
+ :kaocha/fail-fast?                  false
+ :kaocha/color?                      true
+ :kaocha/reporter                    [kaocha.report/dots]
+ :kaocha/plugins                     [:kaocha.plugin/randomize
+                                      :kaocha.plugin/filter
+                                      :kaocha.plugin/capture-output
+                                      :kaocha.plugin/profiling]
+ :kaocha.plugin.randomize/seed       950716166
+ :kaocha.plugin.randomize/randomize? true
+ :kaocha.plugin.profiling/count      3
+ :kaocha.plugin.profiling/profiling? true}

--- a/test/tests.edn
+++ b/test/tests.edn
@@ -9,7 +9,8 @@
  :kaocha/plugins                     [:kaocha.plugin/randomize
                                       :kaocha.plugin/filter
                                       :kaocha.plugin/capture-output
-                                      :kaocha.plugin/profiling]
+                                      :kaocha.plugin/profiling
+                                      :kaocha.plugin/print-invocations]
  :kaocha.plugin.randomize/seed       950716166
  :kaocha.plugin.randomize/randomize? true
  :kaocha.plugin.profiling/count      3


### PR DESCRIPTION
Use kaocha as a test runner to record test-unit-xml output and coverage reports on the test run.