### PR TITLE
Improvements to support execution from Jenkinsfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-1.10.0.442
+      - image: circleci/clojure:openjdk-11-tools-deps-1.10.1.483
 
     working_directory: ~/repo
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
             - clojure-v1-dependencies-{{ checksum "deps.edn" }}
             - clojure-v1-dependencies-
 
-      - run: clojure -Spath
       - run: bin/ci
       - store_test_results:
           path: test-results/kaocha

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
           path: test-results/kaocha
       - store_artifacts:
           path: test-results/coverage
+          destination: coverage
 
       - save_cache:
           paths:

--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,4 +1,5 @@
 ;;; Directory Local Variables
 ;;; For more information see (info "(emacs) Directory Variables")
 
-((nil . ((cider-clojure-cli-global-options . "-A:kaocha"))))
+((nil . ((cider-clojure-cli-global-options . "-A:kaocha")
+         (kaocha-runner-extra-configuration . "{:config-file \"test/tests.edn\"}"))))

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .nrepl-port
 target/
 test-results/
+/bin/clojure
+/clj/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .nrepl-port
+target/
+test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target/
 test-results/
 /bin/clojure
 /clj/
+/.cpcache/
+/resources/role.edn

--- a/README.md
+++ b/README.md
@@ -23,6 +23,29 @@ prefixed clones back to `mitosis-staging` and `mitosis-staging-replica`.
 stack-mitosis will restart the staging application using a provided script, and
 then delete the `old-` prefixed tree.
 
+# Credentials
+
+Stack mitosis uses [aws-api](https://github.com/cognitect-labs/aws-api) to
+interact with AWS. That uses the same credentials preferences as the AWS Java
+client. However, stack-mitosis also supports using STS and prompting for a MFA
+token to authorize use of a limited role for the duration of the operation.
+
+In order to support that the following environment variables need to be present;
+`AWS_CONFIG_FILE`, `AWS_CREDENTIAL_PROFILES_FILE` should be set to specify any
+credentials other than `.aws/credentials`. For the initial handshake with AWS,
+credentials are needed from those files, or from environment variables,
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_REGION`. In order to
+select an assumed role using an MFA token, for now a `role.edn` file should be
+specified with the following values:
+
+```
+{:mfa-serial "arn:aws:iam::1234:mfa/username"
+ :role-arn "arn:aws:iam::1234:role/sudo"
+ :region "us-west-1"}
+```
+
+Hopefully in the future this can be parsed directly from the `AWS_CONFIG` file.
+
 # Usage
 
     clj -m stack-mitosis.cli \

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@ parity with production in a throw-away environment.
 
 ## Example
 
-Given an environment like:
+Given an environment where both staging and production have a database and a replica:
 
-Production Application <-> `mitosis-production` -> `mitosis-production-replica`
-Staging Application <-> `mitosis-staging` -> `mitosis-staging-replica`
+```
+Production Application: mitosis-production -> mitosis-production-replica
+Staging Application: mitosis-staging -> mitosis-staging-replica
+```
 
 Stack mitosis will clone `mitosis-production` into a new tree
 `temp-mitosis-staging` -> `temp-mitosis-staging-replica`. It will then rename

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ then delete the `old-` prefixed tree.
 # Credentials
 
 Stack mitosis uses [aws-api](https://github.com/cognitect-labs/aws-api) to
-interact with AWS. That uses the same credentials preferences as the AWS Java
-client. However, stack-mitosis also supports using STS and prompting for a MFA
-token to authorize use of a limited role for the duration of the operation.
+interact with AWS. That uses the same [credentials
+preferences](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html)
+as the AWS Java client. However, stack-mitosis also supports using STS and
+prompting for a MFA token to authorize use of a limited role for the duration of
+the operation.
 
 In order to support that the following environment variables need to be present;
 `AWS_CONFIG_FILE`, `AWS_CREDENTIAL_PROFILES_FILE` should be set to specify any

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ prefixed clones back to `mitosis-staging` and `mitosis-staging-replica`.
 stack-mitosis will restart the staging application using a provided script, and
 then delete the `old-` prefixed tree.
 
+# Install
+
+After installing a JDK, follow the [clojure install
+instructions](https://clojure.org/guides/getting_started) for your environment
+to ensure `clj` and `clojure` are in path.
+
 # Credentials
 
 Stack mitosis uses [aws-api](https://github.com/cognitect-labs/aws-api) to

--- a/bin/install-clj
+++ b/bin/install-clj
@@ -3,6 +3,10 @@
 # Installs bin/clojure to bootstrap tools.deps installing on Jenkins
 # Use --verify to print dependencies
 
+# TODO: OSX install instructions? However this is primarily for running CI on a
+# unix based Jenkins install, so may not need to be cross platform, so long as
+# the appropriate platform already includes a clojure tools.deps install.
+
 CLJ_VERSION="1.10.1.489"
 # https://clojure.org/guides/getting_started#_installation_on_linux
 curl -O https://download.clojure.org/install/linux-install-$CLJ_VERSION.sh

--- a/bin/install-clj
+++ b/bin/install-clj
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
 
+# Installs bin/clojure to bootstrap tools.deps installing on Jenkins
+# Use --verify to print dependencies
+
 CLJ_VERSION="1.10.1.483"
 # https://clojure.org/guides/getting_started#_installation_on_linux
 curl -O https://download.clojure.org/install/linux-install-$CLJ_VERSION.sh

--- a/bin/install-clj
+++ b/bin/install-clj
@@ -1,0 +1,10 @@
+#!/bin/bash -ex
+
+CLJ_VERSION="1.10.1.483"
+# https://clojure.org/guides/getting_started#_installation_on_linux
+curl -O https://download.clojure.org/install/linux-install-$CLJ_VERSION.sh
+chmod +x linux-install-$CLJ_VERSION.sh
+./linux-install-$CLJ_VERSION.sh -p clj
+rm linux-install-$CLJ_VERSION.sh
+cp -v clj/bin/{clj,clojure} bin
+bin/clojure -Stree

--- a/bin/install-clj
+++ b/bin/install-clj
@@ -7,4 +7,8 @@ chmod +x linux-install-$CLJ_VERSION.sh
 ./linux-install-$CLJ_VERSION.sh -p clj
 rm linux-install-$CLJ_VERSION.sh
 cp -v clj/bin/{clj,clojure} bin
-bin/clojure -Stree
+
+if [[ $1 == '--verify' ]]; then
+    java -version
+    bin/clojure -Stree
+fi

--- a/bin/install-clj
+++ b/bin/install-clj
@@ -3,7 +3,7 @@
 # Installs bin/clojure to bootstrap tools.deps installing on Jenkins
 # Use --verify to print dependencies
 
-CLJ_VERSION="1.10.1.483"
+CLJ_VERSION="1.10.1.489"
 # https://clojure.org/guides/getting_started#_installation_on_linux
 curl -O https://download.clojure.org/install/linux-install-$CLJ_VERSION.sh
 chmod +x linux-install-$CLJ_VERSION.sh

--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,14 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.10.1"}
-  org.clojure/core.async      {:mvn/version "0.4.500"}
+  org.clojure/core.async      {:mvn/version "0.5.527"}
   com.cognitect.aws/api       {:mvn/version "0.8.391"}
-  com.cognitect.aws/endpoints {:mvn/version "1.1.11.664"}
+  com.cognitect.aws/endpoints {:mvn/version "1.1.11.670"}
 
-  com.cognitect.aws/rds       {:mvn/version "758.2.552.0"}
+  com.cognitect.aws/rds       {:mvn/version "770.2.568.0"}
 
   ;; for STS refresh
-  com.cognitect.aws/iam       {:mvn/version "746.2.533.0"}
-  com.cognitect.aws/sts       {:mvn/version "747.2.533.0"}
+  com.cognitect.aws/iam       {:mvn/version "770.2.568.0"}
+  com.cognitect.aws/sts       {:mvn/version "770.2.568.0"}
 
   org.clojure/algo.monads     {:mvn/version "0.1.6"}
 
@@ -32,7 +32,7 @@
   ;; clj -Atest
   :test {:extra-paths ["test"]
          :extra-deps {com.cognitect/test-runner {:git/url "https://github.com/cognitect-labs/test-runner.git"
-                                                 :sha "cb96e80f6f3d3b307c59cbeb49bb0dcb3a2a780b"}}
+                                                 :sha "f7ef16dc3b8332b0d77bc0274578ad5270fbfedd"}}
          :main-opts ["-m" "cognitect.test-runner" "--exclude" ":aws"]}
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}

--- a/deps.edn
+++ b/deps.edn
@@ -38,6 +38,12 @@
            :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}
                         lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
                         lambdaisland/kaocha-cloverage {:mvn/version "0.0-41"}}}
+
+  ;; clj -Aclj-kondo --lint src
+  :clj-kondo
+  {:extra-deps {clj-kondo {:mvn/version "RELEASE"}}
+   :main-opts ["-m" "clj-kondo.main"]}
+
   ;; clj -Acoverage
   :coverage {:extra-deps {cloverage {:mvn/version "RELEASE"}}
              :main-opts ["-m" "cloverage.coverage" "-p" "src"]}}}

--- a/src/stack_mitosis/cli.clj
+++ b/src/stack_mitosis/cli.clj
@@ -9,7 +9,8 @@
 
 ;; TODO: add max-timeout for actions
 ;; TODO: show attempt info like skipped steps in flight plan?
-;; TODO: options to copy-tree instead of replace
+;; TODO: add operation to copy-tree instead of replace
+;; TODO: add operation to refresh replicas for a tree
 (def cli-options
   [["-s" "--source SRC" "Root identifier of database tree to copy from"]
    ["-t" "--target DST" "Root identifier of database tree to copy over"]

--- a/src/stack_mitosis/cli.clj
+++ b/src/stack_mitosis/cli.clj
@@ -50,7 +50,7 @@
               true)
           :else
           (let [last-action (interpreter/evaluate-plan rds plan)]
-            (contains? last-action :ok)))))
+            (not (contains? last-action :ErrorResponse))))))
 
 (defn -main [& args]
   (let [{:keys [ok exit-msg] :as options} (parse-args args)]

--- a/src/stack_mitosis/cli.clj
+++ b/src/stack_mitosis/cli.clj
@@ -46,17 +46,18 @@
                                 (:source options) (:target options)
                                 :restart (:restart options))]
     (cond (:plan options)
-          (println (flight-plan plan))
+          (do (println (flight-plan plan))
+              true)
           :else
-          (interpreter/evaluate-plan rds plan))))
+          (let [last-action (interpreter/evaluate-plan rds plan)]
+            (contains? last-action :ok)))))
 
 (defn -main [& args]
   (let [{:keys [ok exit-msg] :as options} (parse-args args)]
     (when exit-msg
       (println exit-msg)
       (System/exit (if ok 0 1)))
-    (process options)
-    (System/exit 0)
+    (System/exit (if (process options) 0 1))
     ))
 
 (comment

--- a/src/stack_mitosis/cli.clj
+++ b/src/stack_mitosis/cli.clj
@@ -31,7 +31,9 @@
 
 (defn flight-plan
   [plan]
-  (concat ["Flight plan:"] (map r/explain plan)))
+  (->> (map r/explain plan)
+       (concat ["Flight plan:"])
+       (str/join "\n")))
 
 (defn process [options]
   (when-let [creds (:credentials options)]
@@ -43,7 +45,7 @@
                                 (:source options) (:target options)
                                 :restart (:restart options))]
     (cond (:plan options)
-          (println (str/join "\n" (flight-plan plan)))
+          (println (flight-plan plan))
           :else
           (interpreter/evaluate-plan rds plan))))
 

--- a/src/stack_mitosis/example_environment.clj
+++ b/src/stack_mitosis/example_environment.clj
@@ -1,0 +1,32 @@
+(ns stack-mitosis.example-environment
+  (:require [stack-mitosis.helpers :as helpers]
+            [stack-mitosis.operations :as op]
+            [stack-mitosis.planner :as plan]
+            [stack-mitosis.predict :as predict]))
+
+(def template
+  {:DBInstanceClass "db.t3.micro"
+   :Engine "mysql" ;; "postgres"
+   :StorageType "gp2"
+   :AllocatedStorage 5
+   :PubliclyAccessible false
+   :MasterUsername "root"})
+
+(defn create [template]
+  ;; mysql allows replicas of replicas, postgres does not
+  ;; create & create replica of a fresh instance take ~6 minutes
+  [(op/create (merge {:DBInstanceIdentifier "mitosis-root"
+                      :MasterUserPassword (helpers/generate-password)}
+                     template))
+   (op/create (merge {:DBInstanceIdentifier "mitosis-alpha"
+                      :MasterUserPassword (helpers/generate-password)}
+                     template))
+   (op/create-replica "mitosis-alpha" "mitosis-beta")
+   #_(op/create-replica "mitosis-beta" "mitosis-gamma")
+   ])
+
+(defn destroy []
+  (conj (plan/delete-tree (predict/state [] (create template)) "mitosis-alpha")
+        (op/delete "mitosis-root")))
+
+

--- a/src/stack_mitosis/example_environment.clj
+++ b/src/stack_mitosis/example_environment.clj
@@ -18,6 +18,7 @@
   [(op/create (merge {:DBInstanceIdentifier "mitosis-root"
                       :MasterUserPassword (helpers/generate-password)}
                      template))
+   (op/create-replica "mitosis-root" "mitosis-replica")
    (op/create (merge {:DBInstanceIdentifier "mitosis-alpha"
                       :MasterUserPassword (helpers/generate-password)}
                      template))

--- a/src/stack_mitosis/example_environment.clj
+++ b/src/stack_mitosis/example_environment.clj
@@ -27,7 +27,8 @@
    ])
 
 (defn destroy []
-  (conj (plan/delete-tree (predict/state [] (create template)) "mitosis-alpha")
-        (op/delete "mitosis-root")))
+  (let [state (predict/state [] (create template))]
+    (conj (plan/delete-tree state "mitosis-alpha")
+          (plan/delete-tree state "mitosis-root"))))
 
 

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -37,14 +37,14 @@
         (if-let [new-id (r/new-id action)]
           [new-id #(and (op/missing? (describe rds id))
                         (op/completed? (describe rds new-id)))]
-          [id #(op/completed? (describe rds id))])]
-    (let [started (. System (nanoTime))
-          ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 60})
-          msecs (/ (double (- (. System (nanoTime)) started)) 1000000.0)
-          status (-> (describe rds result-id) :DBInstances first :DBInstanceStatus)
-          msg (format "Completed after : %.2fs with status %s" (/ msecs 1000) status)]
-      (log/info msg)
-      ret)))
+          [id #(op/completed? (describe rds id))])
+        started (. System (nanoTime))
+        ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 60})
+        msecs (/ (double (- (. System (nanoTime)) started)) 1000000.0)
+        status (-> (describe rds result-id) :DBInstances first :DBInstanceStatus)
+        msg (format "Completed after : %.2fs with status %s" (/ msecs 1000) status)]
+    (log/info msg)
+    ret))
 
 (defn interpret [rds action]
   (log/infof "Invoking %s" action)

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -18,6 +18,7 @@
 
 (defn databases
   [rds]
+  {:post [(not (empty? %))]}
   (:DBInstances (aws/invoke rds {:op :DescribeDBInstances})))
 
 (defn describe

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -8,7 +8,8 @@
             [stack-mitosis.request :as r]
             [stack-mitosis.shell :as shell]
             [stack-mitosis.sudo :as sudo]
-            [stack-mitosis.wait :as wait]))
+            [stack-mitosis.wait :as wait]
+            [clojure.string :as str]))
 
 ;; TODO: thread this client to all that use it
 (defn client
@@ -86,6 +87,11 @@
   ;; check plan
   (let [state (databases rds)]
     (check-plan state (plan/replace-tree state "mitosis-root" "mitosis-alpha")))
+
+  ;; create a copy of mitosis-root tree
+  (let [state (databases rds)]
+    (->> (partial plan/transform #(str/replace % "root" "copy"))
+         (plan/copy-tree state "mitosis-root" "mitosis-root")))
 
   ;; TODO: move attempt into planning, ie we should skip steps that already happen even in planning
   ;; change wait mechanics to poll all?

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -52,11 +52,11 @@
        (map op/delete)))
 
 (defn transform
-  [prefix instance]
+  [alias-fn instance]
   (-> instance
-      (update :DBInstanceIdentifier (partial aliased prefix))
+      (update :DBInstanceIdentifier alias-fn)
       ;; what about children identifiers?
-      (update-if [:ReadReplicaSourceDBInstanceIdentifier] (partial aliased prefix))))
+      (update-if [:ReadReplicaSourceDBInstanceIdentifier] alias-fn)))
 
 (defn replace-tree
   [instances source target & {:keys [restart]}]
@@ -64,7 +64,7 @@
   ;; predict to update that db for calculating next set of operations by
   ;; applying computation thus far to the initial instances
   ;; TODO something something sequence monad
-  (let [copy (copy-tree instances source target (partial transform "temp"))
+  (let [copy (copy-tree instances source target (partial transform (partial aliased "temp")))
 
         a (predict/state instances copy)
         rename-old (rename-tree a target (partial aliased "old"))

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -108,28 +108,3 @@
            (and (empty? diff-a) (empty? diff-b))))
     [:skip (no-changes (r/db-id action))]
     :else [:ok action]))
-
-(def test-env-template
-  {:DBInstanceClass "db.t3.micro"
-   :Engine "mysql" ;; "postgres"
-   :StorageType "gp2"
-   :AllocatedStorage 5
-   :PubliclyAccessible false
-   :MasterUsername "root"})
-
-(defn make-test-env [template]
-  ;; mysql allows replicas of replicas, postgres does not
-  ;; create & create replica of a fresh instance take ~6 minutes
-  [(op/create (merge {:DBInstanceIdentifier "mitosis-root"
-                      :MasterUserPassword (helpers/generate-password)}
-                     template))
-   (op/create (merge {:DBInstanceIdentifier "mitosis-alpha"
-                      :MasterUserPassword (helpers/generate-password)}
-                     template))
-   (op/create-replica "mitosis-alpha" "mitosis-beta")
-   #_(op/create-replica "mitosis-beta" "mitosis-gamma")
-   ])
-
-(defn cleanup-test-env []
-  (conj (delete-tree (predict/state [] (make-test-env)) "mitosis-alpha")
-        (op/delete "mitosis-root")))

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -12,10 +12,15 @@
   (update db :ReadReplicaDBInstanceIdentifiers
           (partial remove #(= % child-id))))
 
-(defmulti predict (fn [instances op] (get op :op)))
+(defmulti predict
+  "Predict contents of instances db after applying operation to instances.
+
+      (predict [instances op] _) => instances'
+  "
+  (fn [_ op] (get op :op)))
 
 (defmethod predict :shell-command
-  [instances op]
+  [instances _]
   ;; no-op identity
   instances)
 

--- a/src/stack_mitosis/sudo.clj
+++ b/src/stack_mitosis/sudo.clj
@@ -60,6 +60,8 @@
     provider))
 
 (comment
+  ;; Make sure AWS_CONFIG_FILE, AWS_CREDENTIAL_PROFILES_FILE are both set in
+  ;; environment or the appropriate aws key and secret are present.
   (def iam (aws/client {:api :iam}))
   (def sts (aws/client {:api :sts}))
   (keys (aws/ops iam))

--- a/src/stack_mitosis/sudo.clj
+++ b/src/stack_mitosis/sudo.clj
@@ -38,7 +38,7 @@
                          :TokenCode token}}))
 
 (defn credential-provider [token]
-  (when-let [error (:ErrorResponse token)]
+  (when (:ErrorResponse token)
     (throw (ex-info "Invalid token" token)))
   (reify credentials/CredentialsProvider
     (fetch [_]

--- a/test/stack_mitosis/interpreter_test.clj
+++ b/test/stack_mitosis/interpreter_test.clj
@@ -8,9 +8,12 @@
 
 (defn- eval-plan [ops]
   (tlog/with-log
-    (let [r (with-out-str (sut/evaluate-plan nil ops))]
-      {:output (str/split-lines r)
-       :logging (map :message (tlog/the-log))})))
+    (let [capture (new java.io.StringWriter)]
+      (binding [*out* capture]
+        (let [result (sut/evaluate-plan nil ops)]
+          {:output (str/split-lines (str capture))
+           :logging (map :message (tlog/the-log))
+           :last-result result})))))
 
 (defn- mock-invoke
   [instances]
@@ -30,7 +33,9 @@
             ["  exit: 1"]
             :logging
             ["Invoking {:op :shell-command, :request {:cmd \"false\"}}"
-             "Executing [false] failed with status 1"]}
+             "Executing [false] failed with status 1"]
+            :last-result
+            {:ErrorResponse "Executing [false] failed with status 1"}}
            (eval-plan [(op/shell-command "false")
                        (op/shell-command "true")]))
         "early exit")
@@ -41,7 +46,9 @@
             ["Invoking {:op :shell-command, :request {:cmd \"echo 1\"}}"
              "{:ok Executing [echo 1] succeeded}"
              "Invoking {:op :shell-command, :request {:cmd \"echo 2\"}}"
-             "{:ok Executing [echo 2] succeeded}"]}
+             "{:ok Executing [echo 2] succeeded}"]
+            :last-result
+            {:ok "Executing [echo 2] succeeded"}}
            (eval-plan [(op/shell-command "echo 1")
                        (op/shell-command "echo 2")]))
         "execute all")))

--- a/test/stack_mitosis/planner_test.clj
+++ b/test/stack_mitosis/planner_test.clj
@@ -28,7 +28,7 @@
             (op/enable-backups "temp-a")
             (op/create-replica "temp-target" "temp-b")
             (op/create-replica "temp-b" "temp-c")]
-           (plan/copy-tree instances "source" "target" (partial plan/transform "temp"))))))
+           (plan/copy-tree instances "source" "target" (partial plan/transform (partial plan/aliased "temp")))))))
 
 (deftest rename-tree
   (let [instances [{:DBInstanceIdentifier "root" :ReadReplicaDBInstanceIdentifiers ["a" "b"]}


### PR DESCRIPTION
A couple of minor upgrades, todos, test improvements and such to refresh context, but critically this adds `bin/install-clj` which can be leveraged from an external Jenkinsfile to checkout this command, bootstrap clojure with `bin/install-clj`, and then run stack-mitosis using the installed clojure.

The other major change is extracting the example creation into it's own namespace to facilitate running an end-to-end integration test somewhere.

Finally, it adds changes the error status such that commands that exit before completion report as errors correctly.