### PR TITLE
Log error responses from failure at invoke

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,13 +2,13 @@
  {org.clojure/clojure         {:mvn/version "1.10.1"}
   org.clojure/core.async      {:mvn/version "1.1.587"}
   com.cognitect.aws/api       {:mvn/version "0.8.456"}
-  com.cognitect.aws/endpoints {:mvn/version "1.1.11.753"}
+  com.cognitect.aws/endpoints {:mvn/version "1.1.11.783"}
 
-  com.cognitect.aws/rds       {:mvn/version "794.2.642.0"}
+  com.cognitect.aws/rds       {:mvn/version "796.2.662.0"}
 
   ;; for STS refresh
-  com.cognitect.aws/iam       {:mvn/version "788.2.609.0"}
-  com.cognitect.aws/sts       {:mvn/version "773.2.578.0"}
+  com.cognitect.aws/iam       {:mvn/version "796.2.654.0"}
+  com.cognitect.aws/sts       {:mvn/version "798.2.678.0"}
 
   ;; logging
   org.clojure/tools.logging   {:mvn/version "1.1.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.10.1"}
-  org.clojure/core.async      {:mvn/version "1.1.587"}
+  org.clojure/core.async      {:mvn/version "1.2.603"}
   com.cognitect.aws/api       {:mvn/version "0.8.456"}
   com.cognitect.aws/endpoints {:mvn/version "1.1.11.783"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -29,7 +29,7 @@
 
   ;; clj -A:kaocha -m kaocha.runner --config-file test/tests.edn
   :kaocha {:extra-paths ["test"]
-           :extra-deps {lambdaisland/kaocha {:mvn/version "1.0-612"}
+           :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.632"}
                         lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
                         lambdaisland/kaocha-cloverage {:mvn/version "1.0-45"}}}
 

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -39,6 +39,7 @@
   {:post [(seq %)]}
   (:DBInstances (invoke-logged! rds {:op :DescribeDBInstances})))
 
+;; TODO: verify that "old-" database copies do not exist before running
 (defn verify-databases-exist
   [instances identifiers]
   (let [missing-ids (remove (partial lookup/exists? instances) identifiers)]

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -74,7 +74,7 @@
                         (op/completed? (describe rds new-id)))]
           [id #(op/completed? (describe rds id))])
         started (. System (nanoTime))
-        ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 90})
+        ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 120})
         msecs (/ (double (- (. System (nanoTime)) started)) 1000000.0)
         status (-> (describe rds result-id) :DBInstances first :DBInstanceStatus)
         msg (format "Completed after %.2fs with status %s" (/ msecs 1000) status)]

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -76,7 +76,7 @@
         ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 60})
         msecs (/ (double (- (. System (nanoTime)) started)) 1000000.0)
         status (-> (describe rds result-id) :DBInstances first :DBInstanceStatus)
-        msg (format "Completed after : %.2fs with status %s" (/ msecs 1000) status)]
+        msg (format "Completed after %.2fs with status %s" (/ msecs 1000) status)]
     (log/info msg)
     ret))
 

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -74,7 +74,7 @@
                         (op/completed? (describe rds new-id)))]
           [id #(op/completed? (describe rds id))])
         started (. System (nanoTime))
-        ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 60})
+        ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 90})
         msecs (/ (double (- (. System (nanoTime)) started)) 1000000.0)
         status (-> (describe rds result-id) :DBInstances first :DBInstanceStatus)
         msg (format "Completed after %.2fs with status %s" (/ msecs 1000) status)]

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -18,33 +18,41 @@
   []
   (aws/client {:api :rds :credentials-provider (sudo/provider)}))
 
-(defn databases
-  [rds]
-  {:post [(seq %)]}
-  (:DBInstances (aws/invoke rds {:op :DescribeDBInstances})))
-
-(defn list-tags
-  "Mapping of db-id to tags list for each instance in a tree."
-  [rds instances target]
-  (let [tree (plan/list-tree instances target)]
-    (->> tree
-         (map (fn [resource-name]
-                (let [instance (lookup/by-id instances resource-name)
-                      arn (:DBInstanceArn instance)
-                      db-id (:DBInstanceIdentifier instance)]
-                  [db-id (:TagList (aws/invoke rds (op/tags arn)))])))
-         (into {}))))
-
-(defn describe
-  [rds id]
-  (aws/invoke rds (op/describe id)))
-
 (defn- invoke!
   [rds action]
   (if-let [cmd (and (= :shell-command (:op action))
                     (get-in action [:request :cmd]))]
     (shell/bash cmd)
     (aws/invoke rds action)))
+
+(defn- invoke-logged!
+  [rds action]
+  (let [result (invoke! rds action)]
+    (if-let [error-resp (:ErrorResponse result)]
+      (do
+        (log/error error-resp)
+        result)
+      result)))
+
+(defn databases
+  [rds]
+  {:post [(seq %)]}
+  (:DBInstances (invoke-logged! rds {:op :DescribeDBInstances})))
+
+(defn list-tags
+  "Mapping of db-id to tags list for each instance in a tree."
+  [rds instances target]
+  (->> (plan/list-tree instances target)
+       (map (fn [resource-name]
+              (let [instance (lookup/by-id instances resource-name)
+                    arn (:DBInstanceArn instance)
+                    db-id (:DBInstanceIdentifier instance)]
+                [db-id (:TagList (invoke-logged! rds (op/tags arn)))])))
+       (into {})))
+
+(defn describe
+  [rds id]
+  (invoke-logged! rds (op/describe id)))
 
 (defn- wait-for-action
   [rds action]

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -39,6 +39,16 @@
   {:post [(seq %)]}
   (:DBInstances (invoke-logged! rds {:op :DescribeDBInstances})))
 
+(defn verify-databases-exist
+  [instances identifiers]
+  (let [missing-ids (remove (partial lookup/exists? instances) identifiers)]
+    (if (seq missing-ids)
+      (do
+        (log/error "Database(s) do not exist in region: "
+                   (str/join ", " missing-ids))
+        false)
+      true)))
+
 (defn list-tags
   "Mapping of db-id to tags list for each instance in a tree."
   [rds instances target]

--- a/src/stack_mitosis/wait.clj
+++ b/src/stack_mitosis/wait.clj
@@ -17,7 +17,7 @@
       (if-let [resp (pred-fn)]
         (a/>! completed resp)
         (if (< attempt max-attempts)
-          (do (log/debug "Polling Attempt " attempt)
+          (do (log/debug "Polling Attempt" attempt)
               (recur (inc attempt)))
           (a/>! completed :max-attempts))))
     completed))

--- a/src/stack_mitosis/wait.clj
+++ b/src/stack_mitosis/wait.clj
@@ -17,7 +17,7 @@
       (if-let [resp (pred-fn)]
         (a/>! completed resp)
         (if (< attempt max-attempts)
-          (do (log/debug (str "Attempt " attempt))
+          (do (log/debug "Polling Attempt " attempt)
               (recur (inc attempt)))
           (a/>! completed :max-attempts))))
     completed))


### PR DESCRIPTION
Improves error handling by logging any failures from invoke, increasing visibility to permission errors. Adds specific error handling to check if the source or target database does not exist.

Note that when polling for rename, it tests both that the previous db-id is gone and that the new db-id is available. Once the previous database instance is gone, the polling loops report an error that it's missing. That is the expected result. This should be fixed at some point either by waiting for the instance to no longer exist before polling for the new instance to be available, or swallowing that particular error during the polling loop.

Example of this error is:
```
2020-05-21 22:36:43.286 | ERROR | async-dispatch-3 | {:Error {:Type Sender, :TypeAttrs {}, :Code DBInstanceNotFound, :CodeAttrs {}, :Message DBInstance temp-mitosis-demo-replica not found., :MessageAttrs {}}, :ErrorAttrs {}, :RequestId c02e2bd9-3a1b-4eb0-bf65-19b9986a5a8a, :RequestIdAttrs {}}
2020-05-21 22:36:43.579 | DEBUG | async-dispatch-3 | Polling Attempt  0
2020-05-21 22:37:44.457 | ERROR | async-dispatch-4 | {:Error {:Type Sender, :TypeAttrs {}, :Code DBInstanceNotFound, :CodeAttrs {}, :Message DBInstance temp-mitosis-demo-replica not found., :MessageAttrs {}}, :ErrorAttrs {}, :RequestId 75932c79-f44a-4a89-b413-5d6a50d4c14a, :RequestIdAttrs {}}
2020-05-21 22:37:45.011 | INFO  | main | Completed after 122.33s with status available
```

Also updated default timeout to 2 hours for all operations and upgraded the dependencies for communicating with AWS.