### PR TITLE
Calculate IAM Policy required for cloning environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/clojure:openjdk-11-tools-deps-1.10.1.483
+      - image: circleci/clojure:openjdk-11-tools-deps-1.10.1.754
 
     working_directory: ~/repo
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+## [0.5.0]
+
+ - Added `--iam-policy` option for generating a IAM policy for a user or role to clone a replica with a minimal set of permissions.
+ - Updated dependencies
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, Charles L.G. Comstock
+Copyright (c) 2019-2021, Charles L.G. Comstock
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Note that for many cases, even if the clone process is interrupted, the flight p
     bin/kaocha # basic unit tests
     bin/kaocha --plugin cloverage # with coverage output
 
+# Frequently Asked Questions
+
+## Why not use Cloudformation/Terraform
+
+Cloudformation and Terraform are wonderful tools focused on declarative architecture transformation from one steady state to another. Stack-mitosis is focused on safely cloning the contents of a database in one environment to another without changing from one steady state to another. As example, for an environment with production and demo environments, they both exist in the correct configuration before running stack-mitosis, and then after running stack-mitosis the configuration remains the same but the demo environment has a fresh copy of the data from production.
+
+I suspect this could also be accomplished using one of these declarative infrastructure tools by transitioning through multiple intervening states, but have not found any examples of anyone doing that. 
+
 # License
 
 Copyright © 2019-2021 Charles L.G. Comstock

--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ $ clj -m stack-mitosis.cli --source mitosis-prod --target mitosis-demo --iam-pol
   {"Effect":"Allow",
    "Action":["rds:CreateDBInstanceReadReplica"],
    "Resource":
-   ["arn:aws:rds:*:*:db:temp-mitosis-demo",
+   ["arn:aws:rds:*:*:og:*", "arn:aws:rds:*:*:pg:*",
+    "arn:aws:rds:*:*:subgrp:*",
+    "arn:aws:rds:*:*:db:temp-mitosis-demo",
     "arn:aws:rds:*:*:db:temp-mitosis-demo-replica"]},
   {"Effect":"Allow",
    "Action":["rds:PromoteReadReplica"],
@@ -136,7 +138,8 @@ $ clj -m stack-mitosis.cli --source mitosis-prod --target mitosis-demo --iam-pol
   {"Effect":"Allow",
    "Action":["rds:ModifyDBInstance", "rds:RebootDBInstance"],
    "Resource":
-   ["arn:aws:rds:*:*:db:temp-mitosis-demo",
+   ["arn:aws:rds:*:*:og:*", "arn:aws:rds:*:*:subgrp:*",
+    "arn:aws:rds:*:*:db:temp-mitosis-demo",
     "arn:aws:rds:*:*:db:temp-mitosis-demo-replica",
     "arn:aws:rds:*:*:db:mitosis-demo-replica",
     "arn:aws:rds:*:*:db:mitosis-demo"]},

--- a/README.md
+++ b/README.md
@@ -123,28 +123,28 @@ $ clj -m stack-mitosis.cli --source mitosis-prod --target mitosis-demo --iam-pol
  "Statement":
  [{"Effect":"Allow",
    "Action":["rds:DescribeDBInstances", "rds:ListTagsForResource"],
-   "Resource":["arn:aws:rds:::db:*"]},
+   "Resource":["arn:aws:rds:*:*:db:*"]},
   {"Effect":"Allow",
    "Action":["rds:CreateDBInstanceReadReplica"],
    "Resource":
-   ["arn:aws:rds:::db:temp-mitosis-demo",
-    "arn:aws:rds:::db:temp-mitosis-demo-replica"]},
+   ["arn:aws:rds:*:*:db:temp-mitosis-demo",
+    "arn:aws:rds:*:*:db:temp-mitosis-demo-replica"]},
   {"Effect":"Allow",
    "Action":["rds:PromoteReadReplica"],
    "Resource":
-   ["arn:aws:rds:::db:temp-mitosis-demo"]},
+   ["arn:aws:rds:*:*:db:temp-mitosis-demo"]},
   {"Effect":"Allow",
    "Action":["rds:ModifyDBInstance", "rds:RebootInstance"],
    "Resource":
-   ["arn:aws:rds:::db:temp-mitosis-demo",
-    "arn:aws:rds:::db:temp-mitosis-demo-replica",
-    "arn:aws:rds:::db:mitosis-demo-replica",
-    "arn:aws:rds:::db:mitosis-demo"]},
+   ["arn:aws:rds:*:*:db:temp-mitosis-demo",
+    "arn:aws:rds:*:*:db:temp-mitosis-demo-replica",
+    "arn:aws:rds:*:*:db:mitosis-demo-replica",
+    "arn:aws:rds:*:*:db:mitosis-demo"]},
   {"Effect":"Allow",
    "Action":["rds:DeleteDBInstance"],
    "Resource":
-   ["arn:aws:rds:::db:old-mitosis-demo-replica",
-    "arn:aws:rds:::db:old-mitosis-demo"]}]}
+   ["arn:aws:rds:*:*:db:old-mitosis-demo-replica",
+    "arn:aws:rds:*:*:db:old-mitosis-demo"]}]}
 ```
 
 This ensures that a continuous integration or cronjob server like Jenkins can clone production to demo environments on a weekly basis restricted to the minimal permissions necessary. If a user needs to run stack-mitosis for multiple environments (demo, staging, random developer test environment), then a policy can be attached for each environment.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Hopefully in the future this can be parsed directly from the `AWS_CONFIG` file.
     clj -m stack-mitosis.cli \
         --source mitosis-production --target mitosis-staging \
         --restart "./restart-service.sh"
-        --credentials resources/role.edn
+        [--credentials resources/role.edn]
         [--plan]
         [--iam-policy]
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Note that for many cases, even if the clone process is interrupted, the flight p
 
 ## IAM Policy Generation
 
-Stack-mitosis can also generate an IAM policy for an automated user to update a particular environment. The policy uses the database names from the planned changeset to calculate these minimal permissions. While they have been elided from the example below, the ARNs are locked to the account & region.
+Stack-mitosis can also generate an IAM policy for an automated user to update a particular environment. The policy uses the database names from the planned changeset to calculate these minimal permissions. While they have been elided from the example below, the ARNs are locked to the specific account & region used.
 
 ```
 $ clj -m stack-mitosis.cli --source mitosis-prod --target mitosis-demo --iam-policy
@@ -129,17 +129,33 @@ $ clj -m stack-mitosis.cli --source mitosis-prod --target mitosis-demo --iam-pol
    "Resource":
    ["arn:aws:rds:*:*:og:*", "arn:aws:rds:*:*:pg:*",
     "arn:aws:rds:*:*:subgrp:*",
+    "arn:aws:rds:*:*:db:mitosis-prod",
     "arn:aws:rds:*:*:db:temp-mitosis-demo",
+    "arn:aws:rds:*:*:db:temp-mitosis-demo-replica"]},
+  {"Effect":"Allow",
+   "Action":["rds:AddTagsToResource"],
+   "Resource":
+   ["arn:aws:rds:*:*:db:temp-mitosis-demo",
     "arn:aws:rds:*:*:db:temp-mitosis-demo-replica"]},
   {"Effect":"Allow",
    "Action":["rds:PromoteReadReplica"],
    "Resource":
    ["arn:aws:rds:*:*:db:temp-mitosis-demo"]},
   {"Effect":"Allow",
-   "Action":["rds:ModifyDBInstance", "rds:RebootDBInstance"],
+   "Action":["rds:ModifyDBInstance"],
    "Resource":
-   ["arn:aws:rds:*:*:og:*", "arn:aws:rds:*:*:subgrp:*",
+   ["arn:aws:rds:*:*:og:*", "arn:aws:rds:*:*:pg:*",
+    "arn:aws:rds:*:*:secgrp:*", "arn:aws:rds:*:*:subgrp:*",
     "arn:aws:rds:*:*:db:temp-mitosis-demo",
+    "arn:aws:rds:*:*:db:temp-mitosis-demo-replica",
+    "arn:aws:rds:*:*:db:mitosis-demo-replica",
+    "arn:aws:rds:*:*:db:old-mitosis-demo-replica",
+    "arn:aws:rds:*:*:db:mitosis-demo",
+    "arn:aws:rds:*:*:db:old-mitosis-demo"]},
+  {"Effect":"Allow",
+   "Action":["rds:RebootDBInstance"],
+   "Resource":
+   ["arn:aws:rds:*:*:db:temp-mitosis-demo",
     "arn:aws:rds:*:*:db:temp-mitosis-demo-replica",
     "arn:aws:rds:*:*:db:mitosis-demo-replica",
     "arn:aws:rds:*:*:db:mitosis-demo"]},

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ $ clj -m stack-mitosis.cli --source mitosis-prod --target mitosis-demo --iam-pol
    "Resource":
    ["arn:aws:rds:*:*:db:temp-mitosis-demo"]},
   {"Effect":"Allow",
-   "Action":["rds:ModifyDBInstance", "rds:RebootInstance"],
+   "Action":["rds:ModifyDBInstance", "rds:RebootDBInstance"],
    "Resource":
    ["arn:aws:rds:*:*:db:temp-mitosis-demo",
     "arn:aws:rds:*:*:db:temp-mitosis-demo-replica",

--- a/README.md
+++ b/README.md
@@ -116,3 +116,9 @@ Note that for many cases, even if the clone process is interrupted, the flight p
 
     bin/kaocha # basic unit tests
     bin/kaocha --plugin cloverage # with coverage output
+
+# License
+
+Copyright © 2019-2021 Charles L.G. Comstock
+
+Distributed under the BSD-3 Clause License (see LICENSE file)

--- a/bin/ci
+++ b/bin/ci
@@ -8,4 +8,4 @@ bin/kaocha --plugin cloverage \
            --plugin kaocha.plugin/junit-xml \
            --junit-xml-file test-results/kaocha/results.xml
 
-clojure -Aclj-kondo --lint src
+clojure -Aclj-kondo -M --lint src

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clojure -A:kaocha -m kaocha.runner --config-file test/tests.edn "$@"
+clojure -Mkaocha -m kaocha.runner --config-file test/tests.edn "$@"

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clojure -Mkaocha -m kaocha.runner --config-file test/tests.edn "$@"
+clojure -Mkaocha --config-file test/tests.edn "$@"

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-clojure -Mkaocha --config-file test/tests.edn "$@"
+clojure -Mkaocha -m kaocha.runner --config-file test/tests.edn "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,14 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.10.1"}
-  org.clojure/core.async      {:mvn/version "1.2.603"}
-  com.cognitect.aws/api       {:mvn/version "0.8.456"}
-  com.cognitect.aws/endpoints {:mvn/version "1.1.11.783"}
+  org.clojure/core.async      {:mvn/version "1.3.610"}
+  com.cognitect.aws/api       {:mvn/version "0.8.484"}
+  com.cognitect.aws/endpoints {:mvn/version "1.1.11.926"}
 
-  com.cognitect.aws/rds       {:mvn/version "796.2.662.0"}
+  com.cognitect.aws/rds       {:mvn/version "810.2.817.0"}
 
   ;; for STS refresh
-  com.cognitect.aws/iam       {:mvn/version "796.2.654.0"}
-  com.cognitect.aws/sts       {:mvn/version "798.2.678.0"}
+  com.cognitect.aws/iam       {:mvn/version "801.2.704.0"}
+  com.cognitect.aws/sts       {:mvn/version "809.2.784.0"}
 
   ;; logging
   org.clojure/tools.logging   {:mvn/version "1.1.0"}

--- a/deps.edn
+++ b/deps.edn
@@ -23,7 +23,7 @@
   }
  :paths ["src" "resources"]
  :aliases
- {;; clj -A:kaocha -m kaocha.runner --config-file test/tests.edn
+ {;; clj -Mkaocha -m kaocha.runner --config-file test/tests.edn
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
                         lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}

--- a/deps.edn
+++ b/deps.edn
@@ -23,11 +23,12 @@
   }
  :paths ["src" "resources"]
  :aliases
- {;; clj -Mkaocha -m kaocha.runner --config-file test/tests.edn
+ {;; clj -Mkaocha --config-file test/tests.edn
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
                         lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
-                        lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}}}
+                        lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}}
+           :main-opts ["-m" "kaocha.runner"]}
 
   ;; clj -Mclj-kondo --lint src
   :clj-kondo

--- a/deps.edn
+++ b/deps.edn
@@ -29,9 +29,9 @@
 
   ;; clj -A:kaocha -m kaocha.runner --config-file test/tests.edn
   :kaocha {:extra-paths ["test"]
-           :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.632"}
-                        lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
-                        lambdaisland/kaocha-cloverage {:mvn/version "1.0-45"}}}
+           :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
+                        lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
+                        lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}}}
 
   ;; clj -Aclj-kondo --lint src
   :clj-kondo

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,8 @@
 {:deps
  {org.clojure/clojure         {:mvn/version "1.10.1"}
   org.clojure/core.async      {:mvn/version "1.3.610"}
-  com.cognitect.aws/api       {:mvn/version "0.8.484"}
-  com.cognitect.aws/endpoints {:mvn/version "1.1.11.926"}
+  com.cognitect.aws/api       {:mvn/version "0.8.498"}
+  com.cognitect.aws/endpoints {:mvn/version "1.1.11.934"}
 
   com.cognitect.aws/rds       {:mvn/version "810.2.817.0"}
 

--- a/deps.edn
+++ b/deps.edn
@@ -23,11 +23,7 @@
   }
  :paths ["src" "resources"]
  :aliases
- {;; clj -Aoutdated
-  :outdated {:extra-deps {olical/depot {:mvn/version "RELEASE"}}
-             :main-opts ["-m" "depot.outdated.main"]}
-
-  ;; clj -A:kaocha -m kaocha.runner --config-file test/tests.edn
+ {;; clj -A:kaocha -m kaocha.runner --config-file test/tests.edn
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
                         lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}

--- a/deps.edn
+++ b/deps.edn
@@ -29,11 +29,11 @@
                         lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
                         lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}}}
 
-  ;; clj -Aclj-kondo --lint src
+  ;; clj -Mclj-kondo --lint src
   :clj-kondo
-  {:extra-deps {clj-kondo {:mvn/version "RELEASE"}}
+  {:extra-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
    :main-opts ["-m" "clj-kondo.main"]}
 
-  ;; clj -Acoverage
-  :coverage {:extra-deps {cloverage {:mvn/version "RELEASE"}}
+  ;; clj -Mcoverage
+  :coverage {:extra-deps {cloverage/cloverage {:mvn/version "RELEASE"}}
              :main-opts ["-m" "cloverage.coverage" "-p" "src"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -23,12 +23,11 @@
   }
  :paths ["src" "resources"]
  :aliases
- {;; clj -Mkaocha --config-file test/tests.edn
+ {;; clj -Mkaocha -m kaocha.runner --config-file test/tests.edn
   :kaocha {:extra-paths ["test"]
            :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.732"}
                         lambdaisland/kaocha-junit-xml {:mvn/version "0.0.76"}
-                        lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}}
-           :main-opts ["-m" "kaocha.runner"]}
+                        lambdaisland/kaocha-cloverage {:mvn/version "1.0.75"}}}
 
   ;; clj -Mclj-kondo --lint src
   :clj-kondo

--- a/src/stack_mitosis/example_environment.clj
+++ b/src/stack_mitosis/example_environment.clj
@@ -6,9 +6,9 @@
             [stack-mitosis.predict :as predict]))
 
 (def template
-  {:DBInstanceClass "db.t3.micro"
+  {:DBInstanceClass "db.t2.micro"
    :Engine "postgres" ;;"mysql"
-   :StorageType "gp2"
+   :StorageType "gp2" ;; ie ssd storage
    :AllocatedStorage 5
    :PubliclyAccessible false
    :MasterUsername "root"})

--- a/src/stack_mitosis/example_environment.clj
+++ b/src/stack_mitosis/example_environment.clj
@@ -2,6 +2,7 @@
   (:require [stack-mitosis.helpers :as helpers]
             [stack-mitosis.operations :as op]
             [stack-mitosis.planner :as plan]
+            [stack-mitosis.policy :as policy]
             [stack-mitosis.predict :as predict]))
 
 (def template
@@ -53,4 +54,6 @@
     (concat (plan/delete-tree state "mitosis-demo")
             (plan/delete-tree state "mitosis-prod"))))
 
-
+(comment
+  (policy/generate [] (create template))
+  (policy/generate [] (destroy)))

--- a/src/stack_mitosis/example_environment.clj
+++ b/src/stack_mitosis/example_environment.clj
@@ -55,5 +55,7 @@
             (plan/delete-tree state "mitosis-prod"))))
 
 (comment
+  ;; Add fake arn to create template?
   (policy/generate [] (create template))
-  (policy/generate [] (destroy)))
+  ;; Fix this to actual return a functioning delete policy?
+  (policy/generate (predict/state [] (create template)) (destroy)))

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -182,7 +182,6 @@
 
   (list-tags rds instances "mitosis-demo")
 
-  (lookup/by-id (databases rds) "mitosis-prod")
   (let [instances (databases rds)]
     (clojure.data/diff
      (lookup/by-id instances "mitosis-prod")

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -37,7 +37,7 @@
 (defn databases
   [rds]
   {:post [(seq %)]}
-  (:DBInstances (invoke-logged! rds {:op :DescribeDBInstances})))
+  (:DBInstances (invoke-logged! rds (op/describe))))
 
 ;; TODO: verify that "old-" database copies do not exist before running
 (defn verify-databases-exist

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -36,7 +36,9 @@
 
 (defn databases
   [rds]
-  {:post [(seq %)]}
+  ;; FIXME: if account has *no* databases this fails too, need a more nuanced
+  ;; postcondition here
+  ;; {:post [(seq %)]}
   (:DBInstances (invoke-logged! rds (op/describe))))
 
 ;; TODO: verify that "old-" database copies do not exist before running

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -181,6 +181,7 @@
 
   (list-tags rds instances "mitosis-demo")
 
+  (lookup/by-id (databases rds) "mitosis-prod")
   (let [instances (databases rds)]
     (clojure.data/diff
      (lookup/by-id instances "mitosis-prod")

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -36,9 +36,8 @@
 
 (defn databases
   [rds]
-  ;; FIXME: if account has *no* databases this fails too, need a more nuanced
-  ;; postcondition here
-  ;; {:post [(seq %)]}
+  ;; exclude nil, but fresh account might return empty list
+  {:post [(sequential? %)]}
   (:DBInstances (invoke-logged! rds (op/describe))))
 
 ;; TODO: verify that "old-" database copies do not exist before running

--- a/src/stack_mitosis/operations.clj
+++ b/src/stack_mitosis/operations.clj
@@ -43,9 +43,11 @@
   {:op :PromoteReadReplica
    :request {:DBInstanceIdentifier id}})
 
-(defn describe [id]
-  {:op :DescribeDBInstances
-   :request {:DBInstanceIdentifier id}})
+(defn describe
+  ([] {:op :DescribeDBInstances})
+  ([id]
+   {:op :DescribeDBInstances
+    :request {:DBInstanceIdentifier id}}))
 
 (defn tags [db-arn]
   {:op :ListTagsForResource

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -45,4 +45,8 @@
              (reductions predict/predict instances operations)
              operations)]
     (for [[op ops] (group-by :op all-permissions)]
-      (allow [op] (distinct (map :arn ops))))))
+      ;; Give RebootInstance if apply ModifyDBInstance so that ApplyImmediately can reboot
+      (cond (= op :ModifyDBInstance)
+            (allow [op :RebootInstance] (distinct (map :arn ops)))
+            :else
+            (allow [op] (distinct (map :arn ops)))))))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -17,4 +17,6 @@
         resources (group-by :op all-permissions)]
     {:effect "Allow"
      :action (keys resources)
-     :resource (distinct (mapcat :arn resources))}))
+     :resource (distinct (mapcat :arn resources))
+     ;; :raw [all-permissions resources]
+     }))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -57,7 +57,7 @@
             (allow [op] (distinct (map :arn ops)))))))
 
 (defn policy [statements]
-  {:Version "2012-10-17" :Statements statements})
+  {:Version "2012-10-17" :Statement statements})
 
 (defn from-plan [instances operations]
   (policy (concat [(globals)] (generate instances operations))))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -34,6 +34,9 @@
    :action actions
    :resource resources})
 
+(defn globals []
+  (allow [:DescribeDBInstances :ListTagsForResource] ["arn:aws:rds:*"]))
+
 ;; TODO breakup permissions per operation type with better granularity
 ;; ie Delete should only have permissions on old-, not temp- or current staging.
 (defn generate [instances operations]

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -12,16 +12,23 @@
       {:op (:op action)
        :arn (:DBInstanceArn instance)}
       ;; FIXME: this is really gross
+      ;; For create replica cases we don't yet have an instance with an ARN for
+      ;; the newly created id, so we use predict to look ahead a step and use
+      ;; the ARN from the newly created instance.
       (if-let [predicted (lookup/by-id (predict/predict instances action) db-id)]
         {:op (:op action)
          :arn (:DBInstanceArn predicted)}
         ;; fallback to wildcard if we don't recognize
+        ;; This probably should never happen, can we ensure this and drop this
+        ;; case OR should this be a nil arn case?
         {:op (:op action)
          :arn (make-wildcard-arn db-id)}))
     ;; TODO handle ResourceName for ListTagsForResource
     ;; TODO Exclude shell command, and include top level describe?
     {:op (:op action)}))
 
+;; TODO breakup permissions per operation type with better granularity
+;; ie Delete should only have permissions on old-, not temp- or current staging.
 (defn generate [instances operations]
   (let [all-permissions
         (map permissions

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -57,6 +57,7 @@
     (for [[op ops] (group-by :op all-permissions)
           :let [arns (distinct (map :arn ops))]]
       (cond (= op :CreateDBInstanceReadReplica)
+            ;; TODO account for AddTagsToResource on created instances
             (allow [op]
                    (into [(make-arn "*" :type "og")
                           (make-arn "*" :type "pg")

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -1,7 +1,8 @@
 (ns stack-mitosis.policy
   (:require [stack-mitosis.request :as r]
             [stack-mitosis.lookup :as lookup]
-            [stack-mitosis.predict :as predict]))
+            [stack-mitosis.predict :as predict]
+            [clojure.data.json :as json]))
 
 (defn make-wildcard-arn [db-id]
   (str "arn:aws:rds:*:*:db:" db-id))
@@ -30,9 +31,9 @@
 ;; TODO possibly generate optional statement identifier?
 ;; TODO simplify action/resource to singular if only one value?
 (defn allow [actions resources]
-  {:effect "Allow"
-   :action (mapv (partial str "rds") actions)
-   :resource resources})
+  {:Effect "Allow"
+   :Action (mapv (partial str "rds") actions)
+   :Resource resources})
 
 (defn create-example []
   (allow [:CreateDBInstance :AddTagsToResource]
@@ -55,3 +56,9 @@
             (allow [op :RebootInstance] (distinct (map :arn ops)))
             :else
             (allow [op] (distinct (map :arn ops)))))))
+
+(defn as-json [statements]
+  (json/pprint {:Version "2012-10-17" :Statements statements}))
+
+(comment
+  (println (as-json [(globals) (create-example)])))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -47,7 +47,8 @@
    :Resource resources})
 
 (defn create-example []
-  (allow [:CreateDBInstance :AddTagsToResource]
+  ;; TODO handle og, pg, subgrp, secgrp permissions?
+  (allow [:CreateDBInstance :AddTagsToResource :DeleteDBInstance]
          [(make-arn "mitosis-*")]))
 
 (defn globals []

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -7,7 +7,8 @@
     (if-let [instance (lookup/by-id instances db-id)]
       {:op (:op action)
        :arn (:DBInstanceArn instance)}
-      {:op (:op action)})
+      {:op (:op action)
+       :arn "fake arn"})
     ;; TODO handle ResourceName for ListTagsForResource
     ;; TODO Exclude shell command, and include top level describe?
     {:op (:op action)}))
@@ -17,6 +18,4 @@
         resources (group-by :op all-permissions)]
     {:effect "Allow"
      :action (keys resources)
-     :resource (distinct (mapcat :arn resources))
-     ;; :raw [all-permissions resources]
-     }))
+     :resource (distinct (map :arn (flatten (vals resources))))}))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -52,7 +52,7 @@
     (for [[op ops] (group-by :op all-permissions)]
       ;; Give RebootInstance if apply ModifyDBInstance so that ApplyImmediately can reboot
       (cond (= op :ModifyDBInstance)
-            (allow [op :RebootInstance] (distinct (map :arn ops)))
+            (allow [op :RebootDBInstance] (distinct (map :arn ops)))
             :else
             (allow [op] (distinct (map :arn ops)))))))
 

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -10,7 +10,9 @@
   (str/join ":" ["arn:aws:rds" region account-id type db-id]))
 
 (defmulti permissions
-  "Calculate permissions required for a given operation."
+  "Calculate permissions required for a given operation.
+
+      (permissions [instances op]) => [(allow ops arns) ...]"
   (fn [_ action] (get action :op)))
 
 (defmethod permissions :shell-command

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -15,17 +15,17 @@
       {:op (:op action)
        :arn (:DBInstanceArn instance)}
       ;; FIXME: this is really gross
-      ;; For create replica cases we don't yet have an instance with an ARN for
-      ;; the newly created id, so we use predict to look ahead a step and use
-      ;; the ARN from the newly created instance.
-      (if-let [predicted (lookup/by-id (predict/predict instances action) db-id)]
-        {:op (:op action)
-         :arn (:DBInstanceArn predicted)}
-        ;; fallback to wildcard if we don't recognize
-        ;; This probably should never happen, can we ensure this and drop this
-        ;; case OR should this be a nil arn case?
-        {:op (:op action)
-         :arn (make-arn db-id)}))
+      ;; For create replica, use the ARN from the source database
+      (let [source-id (r/source-id action)
+            source (lookup/by-id instances source-id)]
+        (if (and source-id source)
+          {:op (:op action)
+           :arn (:DBInstanceArn source)}
+          ;; fallback to wildcard if we don't recognize
+          ;; This probably should never happen, can we ensure this and drop this
+          ;; case OR should this be a nil arn case?
+          {:op (:op action)
+           :arn (make-arn db-id)})))
     ;; TODO handle ResourceName for ListTagsForResource
     ;; TODO Exclude shell command, and include top level describe?
     {:op (:op action)}))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -1,10 +1,11 @@
 (ns stack-mitosis.policy
   (:require [stack-mitosis.request :as r]
             [stack-mitosis.lookup :as lookup]
-            [stack-mitosis.predict :as predict]))
+            [stack-mitosis.predict :as predict]
+            [clojure.string :as str]))
 
-(defn make-wildcard-arn [db-id]
-  (str "arn:aws:rds:*:*:db:" db-id))
+(defn make-wildcard-arn [db-id & {:keys [type] :or {type "db"}}]
+  (str/join ":" ["arn:aws:rds:*:*" type db-id]))
 
 (defn permissions [instances action]
   (if-let [db-id (r/db-id action)]

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -36,11 +36,11 @@
 
 (defn create-example []
   (allow [:CreateDBInstance :AddTagsToResource]
-         ["arn:aws:rds:*:*:db:mitosis-*"]))
+         [(make-wildcard-arn "mitosis-*")]))
 
 (defn globals []
   (allow [:DescribeDBInstances :ListTagsForResource]
-         ["arn:aws:rds:*"]))
+         [(make-wildcard-arn "*")]))
 
 ;; TODO breakup permissions per operation type with better granularity
 ;; ie Delete should only have permissions on old-, not temp- or current staging.

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -4,7 +4,7 @@
             [stack-mitosis.predict :as predict]))
 
 (defn make-wildcard-arn [db-id]
-  (str "arn:aws:rds:*:*:db:" db-id))
+  (str "arn:aws:rds:::db:" db-id))
 
 (defn permissions [instances action]
   (if-let [db-id (r/db-id action)]

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -1,6 +1,7 @@
 (ns stack-mitosis.policy
   (:require [stack-mitosis.request :as r]
-            [stack-mitosis.lookup :as lookup]))
+            [stack-mitosis.lookup :as lookup]
+            [stack-mitosis.predict :as predict]))
 
 (defn make-wildcard-arn [db-id]
   (str "arn:aws:rds:*:*:db:" db-id))
@@ -10,14 +11,23 @@
     (if-let [instance (lookup/by-id instances db-id)]
       {:op (:op action)
        :arn (:DBInstanceArn instance)}
-      {:op (:op action)
-       :arn (make-wildcard-arn db-id)})
+      ;; FIXME: this is really gross
+      (if-let [predicted (lookup/by-id (predict/predict instances action) db-id)]
+        {:op (:op action)
+         :arn (:DBInstanceArn predicted)}
+        ;; fallback to wildcard if we don't recognize
+        {:op (:op action)
+         :arn (make-wildcard-arn db-id)}))
     ;; TODO handle ResourceName for ListTagsForResource
     ;; TODO Exclude shell command, and include top level describe?
     {:op (:op action)}))
 
 (defn generate [instances operations]
-  (let [all-permissions (map (partial permissions instances) operations)
+  (let [all-permissions
+        (map permissions
+             (reductions predict/predict instances operations)
+             operations)
+
         resources (group-by :op all-permissions)]
     {:effect "Allow"
      :action (keys resources)

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -1,8 +1,7 @@
 (ns stack-mitosis.policy
   (:require [stack-mitosis.request :as r]
             [stack-mitosis.lookup :as lookup]
-            [stack-mitosis.predict :as predict]
-            [clojure.data.json :as json]))
+            [stack-mitosis.predict :as predict]))
 
 (defn make-wildcard-arn [db-id]
   (str "arn:aws:rds:*:*:db:" db-id))
@@ -57,8 +56,12 @@
             :else
             (allow [op] (distinct (map :arn ops)))))))
 
-(defn as-json [statements]
-  (json/pprint {:Version "2012-10-17" :Statements statements}))
+(defn policy [statements]
+  {:Version "2012-10-17" :Statements statements})
+
+(defn from-plan [instances operations]
+  (policy (concat [(globals)] (generate instances operations))))
 
 (comment
-  (println (as-json [(globals) (create-example)])))
+  (require '(clojure.data.json :as json))
+  (json/pprint (policy [(globals) (create-example)])))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -77,7 +77,9 @@
             ;; Give RebootInstance if apply ModifyDBInstance so that ApplyImmediately can reboot
             (allow [op :RebootDBInstance]
                    (into [(make-arn "*" :type "og")
-                          (make-arn "*" :type "subgrp")]
+                          (make-arn "*" :type "pg")
+                          (make-arn "*" :type "subgrp")
+                          (make-arn "*" :type "secgrp")]
                          arns))
             :else
             (allow [op] arns)))))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -52,12 +52,13 @@
         (map permissions
              (reductions predict/predict instances operations)
              operations)]
-    (for [[op ops] (group-by :op all-permissions)]
+    (for [[op ops] (group-by :op all-permissions)
+          :let [arns (distinct (map :arn ops))]]
       ;; Give RebootInstance if apply ModifyDBInstance so that ApplyImmediately can reboot
       (cond (= op :ModifyDBInstance)
-            (allow [op :RebootDBInstance] (distinct (map :arn ops)))
+            (allow [op :RebootDBInstance] arns)
             :else
-            (allow [op] (distinct (map :arn ops)))))))
+            (allow [op] arns)))))
 
 (defn policy [statements]
   {:Version "2012-10-17" :Statement statements})

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -1,0 +1,20 @@
+(ns stack-mitosis.policy
+  (:require [stack-mitosis.request :as r]
+            [stack-mitosis.lookup :as lookup]))
+
+(defn permissions [instances action]
+  (if-let [db-id (r/db-id action)]
+    (if-let [instance (lookup/by-id instances db-id)]
+      {:op (:op action)
+       :arn (:DBInstanceArn instance)}
+      {:op (:op action)})
+    ;; TODO handle ResourceName for ListTagsForResource
+    ;; TODO Exclude shell command, and include top level describe?
+    {:op (:op action)}))
+
+(defn generate [instances operations]
+  (let [all-permissions (map (partial permissions instances) operations)
+        resources (group-by :op all-permissions)]
+    {:effect "Allow"
+     :action (keys resources)
+     :resource (distinct (mapcat :arn resources))}))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -31,7 +31,7 @@
 ;; TODO simplify action/resource to singular if only one value?
 (defn allow [actions resources]
   {:effect "Allow"
-   :action actions
+   :action (mapv (partial str "rds") actions)
    :resource resources})
 
 (defn globals []

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -34,8 +34,13 @@
    :action (mapv (partial str "rds") actions)
    :resource resources})
 
+(defn create-example []
+  (allow [:CreateDBInstance :AddTagsToResource]
+         ["arn:aws:rds:*:*:db:mitosis-*"]))
+
 (defn globals []
-  (allow [:DescribeDBInstances :ListTagsForResource] ["arn:aws:rds:*"]))
+  (allow [:DescribeDBInstances :ListTagsForResource]
+         ["arn:aws:rds:*"]))
 
 ;; TODO breakup permissions per operation type with better granularity
 ;; ie Delete should only have permissions on old-, not temp- or current staging.

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -2,13 +2,16 @@
   (:require [stack-mitosis.request :as r]
             [stack-mitosis.lookup :as lookup]))
 
+(defn make-wildcard-arn [db-id]
+  (str "arn:aws:rds:*:*:db:" db-id))
+
 (defn permissions [instances action]
   (if-let [db-id (r/db-id action)]
     (if-let [instance (lookup/by-id instances db-id)]
       {:op (:op action)
        :arn (:DBInstanceArn instance)}
       {:op (:op action)
-       :arn "fake arn"})
+       :arn (make-wildcard-arn db-id)})
     ;; TODO handle ResourceName for ListTagsForResource
     ;; TODO Exclude shell command, and include top level describe?
     {:op (:op action)}))

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -4,7 +4,7 @@
             [stack-mitosis.predict :as predict]))
 
 (defn make-wildcard-arn [db-id]
-  (str "arn:aws:rds:::db:" db-id))
+  (str "arn:aws:rds:*:*:db:" db-id))
 
 (defn permissions [instances action]
   (if-let [db-id (r/db-id action)]

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -27,7 +27,7 @@
 (defmulti predict
   "Predict contents of instances db after applying operation to instances.
 
-      (predict [instances op] _) => instances'
+      (predict [instances op]) => instances'
   "
   (fn [_ op] (get op :op)))
 

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -85,9 +85,9 @@
         parent (lookup/parent instances current-id)]
     (letfn [(new-name [db]
               (merge (if new-id
-                       (predict-arn (assoc db :DBInstanceIdentifier new-id)
-                                    (:DBInstanceArn db)
-                                    current-id new-id)
+                       (-> db
+                           (assoc :DBInstanceIdentifier new-id)
+                           (predict-arn (:DBInstanceArn db) current-id new-id))
                        db)
                      ;; merge in everything else in request
                      (dissoc (:request op)

--- a/test/stack_mitosis/interpreter_test.clj
+++ b/test/stack_mitosis/interpreter_test.clj
@@ -23,9 +23,11 @@
   (with-redefs [aws/invoke (mock-invoke [{:DBInstanceIdentifier "a"}])]
     (is (= [{:DBInstanceIdentifier "a"}]
            (sut/databases identity))))
-  ;; (with-redefs [aws/invoke (mock-invoke [])]
-  ;;   (is (thrown-with-msg? java.lang.AssertionError #"Assert failed"
-  ;;                         (sut/databases identity))))
+  (with-redefs [aws/invoke (mock-invoke [])]
+    (is (= [] (sut/databases identity))))
+  (with-redefs [aws/invoke (fn [& _] {})]
+    (is (thrown-with-msg? java.lang.AssertionError #"Assert failed"
+                          (sut/databases identity))))
   )
 
 (deftest evaluate-plan

--- a/test/stack_mitosis/interpreter_test.clj
+++ b/test/stack_mitosis/interpreter_test.clj
@@ -23,9 +23,10 @@
   (with-redefs [aws/invoke (mock-invoke [{:DBInstanceIdentifier "a"}])]
     (is (= [{:DBInstanceIdentifier "a"}]
            (sut/databases identity))))
-  (with-redefs [aws/invoke (mock-invoke [])]
-    (is (thrown-with-msg? java.lang.AssertionError #"Assert failed"
-                          (sut/databases identity)))))
+  ;; (with-redefs [aws/invoke (mock-invoke [])]
+  ;;   (is (thrown-with-msg? java.lang.AssertionError #"Assert failed"
+  ;;                         (sut/databases identity))))
+  )
 
 (deftest evaluate-plan
   (with-redefs [aws/invoke (mock-invoke [{:DBInstanceIdentifier "a"}])]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -45,7 +45,7 @@
   (is (= {:Version "2012-10-17"
           :Statement
           [(sut/allow [:DescribeDBInstances :ListTagsForResource]
-                      ["arn:aws:rds:::db:*"])
+                      ["arn:aws:rds:*:*:db:*"])
            (sut/allow [:CreateDBInstanceReadReplica]
                       (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
            (sut/allow [:PromoteReadReplica]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -31,6 +31,7 @@
 
 ;; TODO: how to incorporate permissions for ListTags and DescribeDBInstances
 ;; also how to create policy for example environment creation?
+;; TODO: handle possible need for RebootInstance if renaming with ApplyImmediatly?
 (deftest generate
   (is (= [(sut/allow [:CreateDBInstanceReadReplica]
                      [(make-arn "temp-staging") (make-arn "temp-staging-replica")])

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -1,7 +1,8 @@
 (ns stack-mitosis.policy-test
   (:require [clojure.test :as t :refer [deftest is]]
             [stack-mitosis.operations :as op]
-            [stack-mitosis.policy :as sut]))
+            [stack-mitosis.policy :as sut]
+            [stack-mitosis.planner :as plan]))
 
 (deftest permissions
   (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn "arn:aws:rds:us-east-1"}]
@@ -14,3 +15,18 @@
     (is (= {:op :DescribeDBInstances}
            (sut/permissions [] (op/describe)))
         "operation only if no database identifier in request")))
+
+(deftest generate
+  (let [instances [{:DBInstanceIdentifier "production" :ReadReplicaDBInstanceIdentifiers ["production-replica"]
+                    :DBInstanceArn "production-arn"}
+                   {:DBInstanceIdentifier "production-replica" :ReadReplicaSourceDBInstanceIdentifier "production"
+                    :DBInstanceArn "production-replica-arn"}
+                   {:DBInstanceIdentifier "staging" :ReadReplicaDBInstanceIdentifiers ["staging-replica"]
+                    :DBInstanceArn "staging-arn"}
+                   {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
+                    :DBInstanceArn "staging-replica-arn"}]]
+    (is (= {:effect "Allow"
+            :action [:CreateDBInstanceReadReplica :PromoteReadReplica :ModifyDBInstance :DeleteDBInstance]
+            ;; FIXME: note that create db, promote, and modify may have a different set of resource permissions from delete
+            :resource []}
+           (sut/generate instances (plan/replace-tree instances "production" "staging"))))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -44,7 +44,9 @@
                      (into ["arn:aws:rds:*:*:og:*"
                             "arn:aws:rds:*:*:pg:*"
                             "arn:aws:rds:*:*:subgrp:*"]
-                           (mapv fake-arn ["production" "temp-staging"])))
+                           (mapv fake-arn ["production" "temp-staging" "temp-staging-replica"])))
+          (sut/allow [:AddTagsToResource]
+                     (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
           (sut/allow [:PromoteReadReplica]
                      [(fake-arn "temp-staging")])
           (sut/allow [:ModifyDBInstance :RebootDBInstance]
@@ -65,7 +67,9 @@
                       (into ["arn:aws:rds:*:*:og:*"
                              "arn:aws:rds:*:*:pg:*"
                              "arn:aws:rds:*:*:subgrp:*"]
-                            (mapv fake-arn ["production" "temp-staging"])))
+                            (mapv fake-arn ["production" "temp-staging" "temp-staging-replica"])))
+           (sut/allow [:AddTagsToResource]
+                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
            (sut/allow [:PromoteReadReplica]
                       [(fake-arn "temp-staging")])
            (sut/allow [:ModifyDBInstance :RebootDBInstance]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -17,11 +17,15 @@
    {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
     :DBInstanceArn (fake-arn "staging-replica")}])
 
-(deftest make-wildcard-arn
+(deftest make-arn
   (is (= "arn:aws:rds:*:*:db:production"
-         (sut/make-wildcard-arn "production")))
+         (sut/make-arn "production")))
   (is (= "arn:aws:rds:*:*:og:*"
-         (sut/make-wildcard-arn "*" :type "og"))))
+         (sut/make-arn "*" :type "og")))
+  (is (= "arn:aws:rds:us-east-1:*:db:*"
+         (sut/make-arn "*" :region "us-east-1")))
+  (is (= "arn:aws:rds:*:1234:db:*"
+         (sut/make-arn "*" :account-id "1234"))))
 
 (deftest permissions
   (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn (fake-arn "foo")}]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -44,7 +44,7 @@
                      (into ["arn:aws:rds:*:*:og:*"
                             "arn:aws:rds:*:*:pg:*"
                             "arn:aws:rds:*:*:subgrp:*"]
-                           (mapv fake-arn ["temp-staging" "temp-staging-replica"])))
+                           (mapv fake-arn ["production" "temp-staging"])))
           (sut/allow [:PromoteReadReplica]
                      [(fake-arn "temp-staging")])
           (sut/allow [:ModifyDBInstance :RebootDBInstance]
@@ -65,7 +65,7 @@
                       (into ["arn:aws:rds:*:*:og:*"
                              "arn:aws:rds:*:*:pg:*"
                              "arn:aws:rds:*:*:subgrp:*"]
-                            (mapv fake-arn ["temp-staging" "temp-staging-replica"])))
+                            (mapv fake-arn ["production" "temp-staging"])))
            (sut/allow [:PromoteReadReplica]
                       [(fake-arn "temp-staging")])
            (sut/allow [:ModifyDBInstance :RebootDBInstance]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -68,31 +68,6 @@
              :arn "arn:aws:rds:us-east-1:1234567:db:foo"}]
            (sut/permissions [instance] (op/modify "foo" {}))))))
 
-(deftest generate
-  (is (= [(sut/allow [:CreateDBInstanceReadReplica]
-                     (into ["arn:aws:rds:*:*:og:*"
-                            "arn:aws:rds:*:*:pg:*"
-                            "arn:aws:rds:*:*:subgrp:*"]
-                           (mapv fake-arn ["production" "temp-staging" "temp-staging-replica"])))
-          (sut/allow [:AddTagsToResource]
-                     (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
-          (sut/allow [:PromoteReadReplica]
-                     [(fake-arn "temp-staging")])
-          (sut/allow [:ModifyDBInstance]
-                     (into ["arn:aws:rds:*:*:og:*"
-                            "arn:aws:rds:*:*:pg:*"
-                            "arn:aws:rds:*:*:secgrp:*"
-                            "arn:aws:rds:*:*:subgrp:*"]
-                           (mapv fake-arn ["temp-staging" "temp-staging-replica"
-                                           "staging-replica" "old-staging-replica"
-                                           "staging" "old-staging"])))
-          (sut/allow [:RebootDBInstance]
-                     (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
-          (sut/allow [:DeleteDBInstance]
-                     (mapv fake-arn ["old-staging-replica" "old-staging"]))]
-         (sut/generate (example-instances)
-                       (plan/replace-tree (example-instances) "production" "staging")))))
-
 (deftest from-plan
   (is (= {:Version "2012-10-17"
           :Statement

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -43,7 +43,7 @@
 
 (deftest from-plan
   (is (= {:Version "2012-10-17"
-          :Statements
+          :Statement
           [(sut/allow [:DescribeDBInstances :ListTagsForResource]
                       ["arn:aws:rds:*:*:db:*"])
            (sut/allow [:CreateDBInstanceReadReplica]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -31,13 +31,12 @@
 
 ;; TODO: how to incorporate permissions for ListTags and DescribeDBInstances
 ;; also how to create policy for example environment creation?
-;; TODO: handle possible need for RebootInstance if renaming with ApplyImmediatly?
 (deftest generate
   (is (= [(sut/allow [:CreateDBInstanceReadReplica]
                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
           (sut/allow [:PromoteReadReplica]
                      [(fake-arn "temp-staging")])
-          (sut/allow [:ModifyDBInstance]
+          (sut/allow [:ModifyDBInstance :RebootInstance]
                      (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
           (sut/allow [:DeleteDBInstance]
                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -33,11 +33,11 @@
   (is (= {:effect "Allow"
           :action [:CreateDBInstanceReadReplica :PromoteReadReplica :ModifyDBInstance :DeleteDBInstance]
           ;; FIXME: note that create db, promote, and modify may have a different set of resource permissions from delete
-          :resource [(sut/make-wildcard-arn "temp-staging")
-                     (sut/make-wildcard-arn "temp-staging-replica")
+          :resource [(make-arn "temp-staging")
+                     (make-arn "temp-staging-replica")
                      (make-arn "staging-replica")
                      (make-arn "staging")
-                     (sut/make-wildcard-arn "old-staging-replica")
-                     (sut/make-wildcard-arn "old-staging")]}
+                     (make-arn "old-staging-replica")
+                     (make-arn "old-staging")]}
          (sut/generate (example-instances)
                        (plan/replace-tree (example-instances) "production" "staging")))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -40,3 +40,19 @@
                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]
          (sut/generate (example-instances)
                        (plan/replace-tree (example-instances) "production" "staging")))))
+
+(deftest from-plan
+  (is (= {:Version "2012-10-17"
+          :Statements
+          [(sut/allow [:DescribeDBInstances :ListTagsForResource]
+                      ["arn:aws:rds:*:*:db:*"])
+           (sut/allow [:CreateDBInstanceReadReplica]
+                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
+           (sut/allow [:PromoteReadReplica]
+                      [(fake-arn "temp-staging")])
+           (sut/allow [:ModifyDBInstance :RebootInstance]
+                      (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
+           (sut/allow [:DeleteDBInstance]
+                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
+         (sut/from-plan (example-instances)
+                        (plan/replace-tree (example-instances) "production" "staging")))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -45,7 +45,7 @@
   (is (= {:Version "2012-10-17"
           :Statement
           [(sut/allow [:DescribeDBInstances :ListTagsForResource]
-                      ["arn:aws:rds:*:*:db:*"])
+                      ["arn:aws:rds:::db:*"])
            (sut/allow [:CreateDBInstanceReadReplica]
                       (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
            (sut/allow [:PromoteReadReplica]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -37,7 +37,36 @@
         "operation and arn if instance is found")
     (is (= [{:op :DescribeDBInstances}]
            (sut/permissions [] (op/describe)))
-        "operation only if no database identifier in request")))
+        "operation only if no database identifier in request")
+    (is (= [{:op :CreateDBInstanceReadReplica
+             :arn ["arn:aws:rds:*:*:og:*"
+                   "arn:aws:rds:*:*:pg:*"
+                   "arn:aws:rds:*:*:subgrp:*"
+                   "arn:aws:rds:us-east-1:1234567:db:foo"
+                   "arn:aws:rds:us-east-1:1234567:db:bar"]}
+            {:op :AddTagsToResource
+             :arn "arn:aws:rds:us-east-1:1234567:db:bar"}]
+           (sut/permissions [instance] (op/create-replica "foo" "bar"))))
+    (is (= [{:op :ModifyDBInstance
+             :arn ["arn:aws:rds:*:*:og:*"
+                   "arn:aws:rds:*:*:pg:*"
+                   "arn:aws:rds:*:*:secgrp:*"
+                   "arn:aws:rds:*:*:subgrp:*"
+                   "arn:aws:rds:us-east-1:1234567:db:foo"]}
+            {:op :ModifyDBInstance
+             :arn "arn:aws:rds:us-east-1:1234567:db:bar"}
+            {:op :RebootDBInstance
+             :arn "arn:aws:rds:us-east-1:1234567:db:foo"}]
+           (sut/permissions [instance] (op/rename "foo" "bar"))))
+    (is (= [{:op :ModifyDBInstance
+             :arn ["arn:aws:rds:*:*:og:*"
+                   "arn:aws:rds:*:*:pg:*"
+                   "arn:aws:rds:*:*:secgrp:*"
+                   "arn:aws:rds:*:*:subgrp:*"
+                   "arn:aws:rds:us-east-1:1234567:db:foo"]}
+            {:op :RebootDBInstance
+             :arn "arn:aws:rds:us-east-1:1234567:db:foo"}]
+           (sut/permissions [instance] (op/modify "foo" {}))))))
 
 (deftest generate
   (is (= [(sut/allow [:CreateDBInstanceReadReplica]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -34,7 +34,7 @@
 ;; TODO: handle possible need for RebootInstance if renaming with ApplyImmediatly?
 (deftest generate
   (is (= [(sut/allow [:CreateDBInstanceReadReplica]
-                     [(make-arn "temp-staging") (make-arn "temp-staging-replica")])
+                     (mapv make-arn ["temp-staging" "temp-staging-replica"]))
           (sut/allow [:PromoteReadReplica]
                      [(make-arn "temp-staging")])
           (sut/allow [:ModifyDBInstance]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -17,6 +17,12 @@
    {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
     :DBInstanceArn (fake-arn "staging-replica")}])
 
+(deftest make-wildcard-arn
+  (is (= "arn:aws:rds:*:*:db:production"
+         (sut/make-wildcard-arn "production")))
+  (is (= "arn:aws:rds:*:*:og:*"
+         (sut/make-wildcard-arn "*" :type "og"))))
+
 (deftest permissions
   (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn (fake-arn "foo")}]
     (is (= {:op :DeleteDBInstance :arn (fake-arn "foo")}

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -34,7 +34,7 @@
                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
           (sut/allow [:PromoteReadReplica]
                      [(fake-arn "temp-staging")])
-          (sut/allow [:ModifyDBInstance :RebootInstance]
+          (sut/allow [:ModifyDBInstance :RebootDBInstance]
                      (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
           (sut/allow [:DeleteDBInstance]
                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]
@@ -50,7 +50,7 @@
                       (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
            (sut/allow [:PromoteReadReplica]
                       [(fake-arn "temp-staging")])
-           (sut/allow [:ModifyDBInstance :RebootInstance]
+           (sut/allow [:ModifyDBInstance :RebootDBInstance]
                       (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -41,11 +41,16 @@
 
 (deftest generate
   (is (= [(sut/allow [:CreateDBInstanceReadReplica]
-                     (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
+                     (into ["arn:aws:rds:*:*:og:*"
+                            "arn:aws:rds:*:*:pg:*"
+                            "arn:aws:rds:*:*:subgrp:*"]
+                           (mapv fake-arn ["temp-staging" "temp-staging-replica"])))
           (sut/allow [:PromoteReadReplica]
                      [(fake-arn "temp-staging")])
           (sut/allow [:ModifyDBInstance :RebootDBInstance]
-                     (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
+                     (into ["arn:aws:rds:*:*:og:*"
+                            "arn:aws:rds:*:*:subgrp:*"]
+                           (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"])))
           (sut/allow [:DeleteDBInstance]
                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]
          (sut/generate (example-instances)
@@ -57,11 +62,16 @@
           [(sut/allow [:DescribeDBInstances :ListTagsForResource]
                       ["arn:aws:rds:*:*:db:*"])
            (sut/allow [:CreateDBInstanceReadReplica]
-                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
+                      (into ["arn:aws:rds:*:*:og:*"
+                             "arn:aws:rds:*:*:pg:*"
+                             "arn:aws:rds:*:*:subgrp:*"]
+                            (mapv fake-arn ["temp-staging" "temp-staging-replica"])))
            (sut/allow [:PromoteReadReplica]
                       [(fake-arn "temp-staging")])
            (sut/allow [:ModifyDBInstance :RebootDBInstance]
-                      (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
+                      (into ["arn:aws:rds:*:*:og:*"
+                             "arn:aws:rds:*:*:subgrp:*"]
+                            (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"])))
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
          (sut/from-plan (example-instances)

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -16,7 +16,7 @@
 
 (deftest permissions
   (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn "arn:aws:rds:us-east-1"}]
-    (is (= {:op :DeleteDBInstance}
+    (is (= {:op :DeleteDBInstance :arn "fake arn"}
            (sut/permissions [] (op/delete "foo")))
         "only operation if instance is not found")
     (is (= {:op :DeleteDBInstance :arn "arn:aws:rds:us-east-1"}
@@ -30,6 +30,6 @@
   (is (= {:effect "Allow"
           :action [:CreateDBInstanceReadReplica :PromoteReadReplica :ModifyDBInstance :DeleteDBInstance]
           ;; FIXME: note that create db, promote, and modify may have a different set of resource permissions from delete
-          :resource []}
+          :resource ["fake arn" "staging-replica-arn" "staging-arn"]}
          (sut/generate (example-instances)
                        (plan/replace-tree (example-instances) "production" "staging")))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -1,0 +1,16 @@
+(ns stack-mitosis.policy-test
+  (:require [clojure.test :as t :refer [deftest is]]
+            [stack-mitosis.operations :as op]
+            [stack-mitosis.policy :as sut]))
+
+(deftest permissions
+  (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn "arn:aws:rds:us-east-1"}]
+    (is (= {:op :DeleteDBInstance}
+           (sut/permissions [] (op/delete "foo")))
+        "only operation if instance is not found")
+    (is (= {:op :DeleteDBInstance :arn "arn:aws:rds:us-east-1"}
+           (sut/permissions [instance] (op/delete "foo")))
+        "operation and arn if instance is found")
+    (is (= {:op :DescribeDBInstances}
+           (sut/permissions [] (op/describe)))
+        "operation only if no database identifier in request")))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -4,6 +4,16 @@
             [stack-mitosis.policy :as sut]
             [stack-mitosis.planner :as plan]))
 
+(defn example-instances []
+  [{:DBInstanceIdentifier "production" :ReadReplicaDBInstanceIdentifiers ["production-replica"]
+    :DBInstanceArn "production-arn"}
+   {:DBInstanceIdentifier "production-replica" :ReadReplicaSourceDBInstanceIdentifier "production"
+    :DBInstanceArn "production-replica-arn"}
+   {:DBInstanceIdentifier "staging" :ReadReplicaDBInstanceIdentifiers ["staging-replica"]
+    :DBInstanceArn "staging-arn"}
+   {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
+    :DBInstanceArn "staging-replica-arn"}])
+
 (deftest permissions
   (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn "arn:aws:rds:us-east-1"}]
     (is (= {:op :DeleteDBInstance}
@@ -17,16 +27,9 @@
         "operation only if no database identifier in request")))
 
 (deftest generate
-  (let [instances [{:DBInstanceIdentifier "production" :ReadReplicaDBInstanceIdentifiers ["production-replica"]
-                    :DBInstanceArn "production-arn"}
-                   {:DBInstanceIdentifier "production-replica" :ReadReplicaSourceDBInstanceIdentifier "production"
-                    :DBInstanceArn "production-replica-arn"}
-                   {:DBInstanceIdentifier "staging" :ReadReplicaDBInstanceIdentifiers ["staging-replica"]
-                    :DBInstanceArn "staging-arn"}
-                   {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
-                    :DBInstanceArn "staging-replica-arn"}]]
-    (is (= {:effect "Allow"
-            :action [:CreateDBInstanceReadReplica :PromoteReadReplica :ModifyDBInstance :DeleteDBInstance]
-            ;; FIXME: note that create db, promote, and modify may have a different set of resource permissions from delete
-            :resource []}
-           (sut/generate instances (plan/replace-tree instances "production" "staging"))))))
+  (is (= {:effect "Allow"
+          :action [:CreateDBInstanceReadReplica :PromoteReadReplica :ModifyDBInstance :DeleteDBInstance]
+          ;; FIXME: note that create db, promote, and modify may have a different set of resource permissions from delete
+          :resource []}
+         (sut/generate (example-instances)
+                       (plan/replace-tree (example-instances) "production" "staging")))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -49,12 +49,16 @@
                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
           (sut/allow [:PromoteReadReplica]
                      [(fake-arn "temp-staging")])
-          (sut/allow [:ModifyDBInstance :RebootDBInstance]
+          (sut/allow [:ModifyDBInstance]
                      (into ["arn:aws:rds:*:*:og:*"
                             "arn:aws:rds:*:*:pg:*"
-                            "arn:aws:rds:*:*:subgrp:*"
-                            "arn:aws:rds:*:*:secgrp:*"]
-                           (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"])))
+                            "arn:aws:rds:*:*:secgrp:*"
+                            "arn:aws:rds:*:*:subgrp:*"]
+                           (mapv fake-arn ["temp-staging" "temp-staging-replica"
+                                           "staging-replica" "old-staging-replica"
+                                           "staging" "old-staging"])))
+          (sut/allow [:RebootDBInstance]
+                     (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
           (sut/allow [:DeleteDBInstance]
                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]
          (sut/generate (example-instances)
@@ -74,12 +78,16 @@
                       (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
            (sut/allow [:PromoteReadReplica]
                       [(fake-arn "temp-staging")])
-           (sut/allow [:ModifyDBInstance :RebootDBInstance]
+           (sut/allow [:ModifyDBInstance]
                       (into ["arn:aws:rds:*:*:og:*"
                              "arn:aws:rds:*:*:pg:*"
-                             "arn:aws:rds:*:*:subgrp:*"
-                             "arn:aws:rds:*:*:secgrp:*"]
-                            (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"])))
+                             "arn:aws:rds:*:*:secgrp:*"
+                             "arn:aws:rds:*:*:subgrp:*"]
+                            (mapv fake-arn ["temp-staging" "temp-staging-replica"
+                                            "staging-replica" "old-staging-replica"
+                                            "staging" "old-staging"])))
+           (sut/allow [:RebootDBInstance]
+                      (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
          (sut/from-plan (example-instances)

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -29,8 +29,6 @@
            (sut/permissions [] (op/describe)))
         "operation only if no database identifier in request")))
 
-;; TODO: how to incorporate permissions for ListTags and DescribeDBInstances
-;; also how to create policy for example environment creation?
 (deftest generate
   (is (= [(sut/allow [:CreateDBInstanceReadReplica]
                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -51,7 +51,9 @@
                      [(fake-arn "temp-staging")])
           (sut/allow [:ModifyDBInstance :RebootDBInstance]
                      (into ["arn:aws:rds:*:*:og:*"
-                            "arn:aws:rds:*:*:subgrp:*"]
+                            "arn:aws:rds:*:*:pg:*"
+                            "arn:aws:rds:*:*:subgrp:*"
+                            "arn:aws:rds:*:*:secgrp:*"]
                            (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"])))
           (sut/allow [:DeleteDBInstance]
                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]
@@ -74,7 +76,9 @@
                       [(fake-arn "temp-staging")])
            (sut/allow [:ModifyDBInstance :RebootDBInstance]
                       (into ["arn:aws:rds:*:*:og:*"
-                             "arn:aws:rds:*:*:subgrp:*"]
+                             "arn:aws:rds:*:*:pg:*"
+                             "arn:aws:rds:*:*:subgrp:*"
+                             "arn:aws:rds:*:*:secgrp:*"]
                             (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"])))
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -29,13 +29,13 @@
 
 (deftest permissions
   (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn (fake-arn "foo")}]
-    (is (= {:op :DeleteDBInstance :arn (fake-arn "foo")}
+    (is (= [{:op :DeleteDBInstance :arn (fake-arn "foo")}]
            (sut/permissions [instance] (op/delete "foo")))
         "only operation if instance is not found")
-    (is (= {:op :DeleteDBInstance :arn (fake-arn "foo")}
+    (is (= [{:op :DeleteDBInstance :arn (fake-arn "foo")}]
            (sut/permissions [instance] (op/delete "foo")))
         "operation and arn if instance is found")
-    (is (= {:op :DescribeDBInstances}
+    (is (= [{:op :DescribeDBInstances}]
            (sut/permissions [] (op/describe)))
         "operation only if no database identifier in request")))
 

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -4,25 +4,25 @@
             [stack-mitosis.policy :as sut]
             [stack-mitosis.planner :as plan]))
 
-(defn make-arn [name]
+(defn fake-arn [name]
   (str "arn:aws:rds:us-east-1:1234567:db:" name))
 
 (defn example-instances []
   [{:DBInstanceIdentifier "production" :ReadReplicaDBInstanceIdentifiers ["production-replica"]
-    :DBInstanceArn (make-arn "production")}
+    :DBInstanceArn (fake-arn "production")}
    {:DBInstanceIdentifier "production-replica" :ReadReplicaSourceDBInstanceIdentifier "production"
-    :DBInstanceArn (make-arn "production-replica")}
+    :DBInstanceArn (fake-arn "production-replica")}
    {:DBInstanceIdentifier "staging" :ReadReplicaDBInstanceIdentifiers ["staging-replica"]
-    :DBInstanceArn (make-arn "staging")}
+    :DBInstanceArn (fake-arn "staging")}
    {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
-    :DBInstanceArn (make-arn "staging-replica")}])
+    :DBInstanceArn (fake-arn "staging-replica")}])
 
 (deftest permissions
-  (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn (make-arn "foo")}]
-    (is (= {:op :DeleteDBInstance :arn (make-arn "foo")}
+  (let [instance {:DBInstanceIdentifier "foo" :DBInstanceArn (fake-arn "foo")}]
+    (is (= {:op :DeleteDBInstance :arn (fake-arn "foo")}
            (sut/permissions [instance] (op/delete "foo")))
         "only operation if instance is not found")
-    (is (= {:op :DeleteDBInstance :arn (make-arn "foo")}
+    (is (= {:op :DeleteDBInstance :arn (fake-arn "foo")}
            (sut/permissions [instance] (op/delete "foo")))
         "operation and arn if instance is found")
     (is (= {:op :DescribeDBInstances}
@@ -34,12 +34,12 @@
 ;; TODO: handle possible need for RebootInstance if renaming with ApplyImmediatly?
 (deftest generate
   (is (= [(sut/allow [:CreateDBInstanceReadReplica]
-                     (mapv make-arn ["temp-staging" "temp-staging-replica"]))
+                     (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
           (sut/allow [:PromoteReadReplica]
-                     [(make-arn "temp-staging")])
+                     [(fake-arn "temp-staging")])
           (sut/allow [:ModifyDBInstance]
-                     (mapv make-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
+                     (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
           (sut/allow [:DeleteDBInstance]
-                     (mapv make-arn ["old-staging-replica" "old-staging"]))]
+                     (mapv fake-arn ["old-staging-replica" "old-staging"]))]
          (sut/generate (example-instances)
                        (plan/replace-tree (example-instances) "production" "staging")))))

--- a/test/stack_mitosis/predict_test.clj
+++ b/test/stack_mitosis/predict_test.clj
@@ -51,11 +51,13 @@
                                  :SourceDBInstanceIdentifier "root"
                                  :Port 123}})))
     (testing "propagate only *some* instance fields to replica"
-      (let [root {:DBInstanceIdentifier "root" :BackupRetentionPeriod 1
+      (let [root {:DBInstanceIdentifier "root"
+                  :DBInstanceArn "arn:aws:rds:us-west-2:1234567:db:root"
                   :ReadReplicaDBInstanceIdentifiers ["other-clone"]
-                  :Port 123}]
+                  :Port 123 :BackupRetentionPeriod 1}]
         (is (= [(update-in root [:ReadReplicaDBInstanceIdentifiers] conj "clone")
-                {:DBInstanceIdentifier "clone" :ReadReplicaSourceDBInstanceIdentifier "root" :Port 123}]
+                {:DBInstanceIdentifier "clone" :DBInstanceArn "arn:aws:rds:us-west-2:1234567:db:clone"
+                 :ReadReplicaSourceDBInstanceIdentifier "root" :Port 123}]
                (p/predict [root] (op/create-replica "root" "clone"))))))))
 
 (deftest delete

--- a/test/stack_mitosis/predict_test.clj
+++ b/test/stack_mitosis/predict_test.clj
@@ -13,13 +13,14 @@
                                    (op/create {:DBInstanceIdentifier "a"})))))
 
 (deftest modify
-  (let [instances [{:DBInstanceIdentifier "a"}
-                   {:DBInstanceIdentifier "b"}]]
-    (is (= [{:DBInstanceIdentifier "a"}
-            {:DBInstanceIdentifier "new-name"}]
+  (let [instances [{:DBInstanceIdentifier "a" :DBInstanceArn "db:a"}
+                   {:DBInstanceIdentifier "b" :DBInstanceArn "db:b"}]]
+    (is (= [{:DBInstanceIdentifier "a" :DBInstanceArn "db:a"}
+            {:DBInstanceIdentifier "new-name" :DBInstanceArn "db:new-name"}]
            (p/predict instances (op/rename "b" "new-name"))))
-    (is (= [{:DBInstanceIdentifier "a"}
-            {:DBInstanceIdentifier "b" :MultiAZ true}]
+    (is (= [{:DBInstanceIdentifier "a" :DBInstanceArn "db:a"}
+            {:DBInstanceIdentifier "b" :DBInstanceArn "db:b"
+             :MultiAZ true}]
            (p/predict instances
                       (op/modify "b" {:MultiAZ true}))))))
 

--- a/test/stack_mitosis/predict_test.clj
+++ b/test/stack_mitosis/predict_test.clj
@@ -41,10 +41,13 @@
                           (p/predict [] (op/promote "root"))))))
 
 (deftest create-replica
-  (let [instances [{:DBInstanceIdentifier "root" :MultiAZ false}]]
+  (let [instances [{:DBInstanceIdentifier "root" :DBInstanceArn "db:root"
+                    :MultiAZ false}]]
     (is (= [{:DBInstanceIdentifier "root" :MultiAZ false
+             :DBInstanceArn "db:root"
              :ReadReplicaDBInstanceIdentifiers ["replica"]}
             {:DBInstanceIdentifier "replica" :MultiAZ false :Port 123
+             :DBInstanceArn "db:replica"
              :ReadReplicaSourceDBInstanceIdentifier "root"}]
            (p/predict instances
                       {:op :CreateDBInstanceReadReplica


### PR DESCRIPTION
Calculates an IAM policy with the minimal surface area of actions to amazon resource names to complete a clone operation successfully.

TODO:

 - [x] Verified for Postgres
 - [x] Verified for MySQL
 - [x] ~~Consider if pg, og, secgrp, subgrp ARNs can be any more specific and document~~
    Documented concern in `stack-mitosis.policy`, can tighten them later.