### PR TITLE
Add support for cross-vpc cloning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ test-results/
 /clj/
 /.cpcache/
 /resources/role.edn
+.terraform/
+*.tfstate
+*.tfstate.backup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 ### Added
 
+## [0.6.0]
+
+ - Added the ability to clone with source and target instances in different VPCs, by automatically falling back to `RestoreDBInstanceFromDBSnapshot`, instead of `CreateDBInstanceReadReplica`
+   - The restore will be done based on the latest snapshot available, which is usually at most 24h stale.
+ - Added `--restore-snapshot` to force even same-VPC clones to be done with `RestoreDBInstanceFromDBSnapshot` (it's currently faster)
+ - Added a terrafrom environment for testing
+
 ## [0.5.0]
 
  - Added `--iam-policy` option for generating a IAM policy for a user or role to clone a replica with a minimal set of permissions.
  - Updated dependencies
-

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Once that is complete, it's safe to rename the `temp-` prefixed clones back to `
 
 Note that this replication graph is a simple case, but it supports replacing arbitrarily complex replication graphs on RDS and has been verified with mysql and postgres database engines. The postgres engine on RDS only allows multiple replicas of a single primary, but the Mysql engine on RDS allows cascading replicas of replicas. See the AWS documentation for [working with RDS read replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.html) for more information on these limitations.
 
+In the case where source and target instances live in different VPCs, or in case `--restore-snapshot` is used, the first instance (`temp-mitosis-demo` here) is created by restoring the latest available snapshot, instead of using replication. This also skips the promote replica step. All other steps remain the same.
+
 # Install
 
 After installing a JDK, follow the [clojure install
@@ -79,6 +81,7 @@ Hopefully in the future this can be parsed directly from the `AWS_CONFIG` file.
         [--credentials resources/role.edn]
         [--plan]
         [--iam-policy]
+        [--restore-snapshot]
 
 ## Flight Plan
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ data parity with production in a throw-away environment.
 
 ## Process
 
-Suppose for testing or sales purposes it is necessary to maintain an independent application stack with it's own database, which needs to periodically refresh data from the production database. To simplify the illustration, this will focus on the changes to the [AWS RDS](https://aws.amazon.com/rds/) database replication graphs, and omit the application and other services it may depend on. 
+Suppose for testing or sales purposes it is necessary to maintain an independent application stack with it's own database, which needs to periodically refresh data from the production database. To simplify the illustration, this will focus on the changes to the [AWS RDS](https://aws.amazon.com/rds/) database replication graphs, and omit the application and other services it may depend on.
 
 Consider two independent application stacks, production and demo, with primary databases `mitosis-prod` and `mitosis-demo` respectively. Each stack has a replication graph where a primary database is followed by one replica, ie `mitosis-prod` replicates to `mitosis-prod-replica` and `mitosis-demo` replicates to `mitosis-demo-replica`.
 
@@ -34,7 +34,7 @@ Once that is complete, it's safe to rename the `temp-` prefixed clones back to `
 
 ![img](doc/img/rename-2.png)
 
- However, as this is a DNS swap, the application is likely still connected to the original `old-mitosis-demo`. By specifying a restart script, stack-mitosis can force the demo application to restart, and connect to the newly created `mitosis-demo` with fresh data from production. Once it has restarted the application successfully, it deletes the `old-` prefixed database instances from the original demo replication graph.
+However, as this is a DNS swap, the application is likely still connected to the original `old-mitosis-demo`. By specifying a restart script, stack-mitosis can force the demo application to restart, and connect to the newly created `mitosis-demo` with fresh data from production. Once it has restarted the application successfully, it deletes the `old-` prefixed database instances from the original demo replication graph.
 
 ![img](doc/img/final.png)
 
@@ -85,7 +85,7 @@ Hopefully in the future this can be parsed directly from the `AWS_CONFIG` file.
 
 ## Flight Plan
 
-The `--plan` flag will give a flight plan showing the expected list of API calls it's planning on executing against the Amazon API. 
+The `--plan` flag will give a flight plan showing the expected list of API calls it's planning on executing against the Amazon API.
 
 ```
 $ clj -m stack-mitosis.cli --source mitosis-prod --target mitosis-demo --plan
@@ -182,7 +182,7 @@ This ensures that a continuous integration or cronjob server like Jenkins can cl
 
 Cloudformation and Terraform are wonderful tools focused on declarative architecture transformation from one steady state to another. Stack-mitosis is focused on safely cloning the contents of a database in one environment to another without changing from one steady state to another. As example, for an environment with production and demo environments, they both exist in the correct configuration before running stack-mitosis, and then after running stack-mitosis the configuration remains the same but the demo environment has a fresh copy of the data from production.
 
-I suspect this could also be accomplished using one of these declarative infrastructure tools by transitioning through multiple intervening states, but have not found any examples of anyone doing that. 
+I suspect this could also be accomplished using one of these declarative infrastructure tools by transitioning through multiple intervening states, but have not found any examples of anyone doing that.
 
 # License
 

--- a/resources/log4j.properties
+++ b/resources/log4j.properties
@@ -2,3 +2,4 @@ log4j.rootLogger=DEBUG, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} | %-5p | %t | %m%n
+log4j.appender.console.Target=System.err

--- a/src/stack_mitosis/cli.clj
+++ b/src/stack_mitosis/cli.clj
@@ -53,7 +53,8 @@
         instances (interpreter/databases rds)]
     (when (interpreter/verify-databases-exist instances [source target])
       (let [tags (interpreter/list-tags rds instances target)
-            plan (plan/replace-tree instances source target
+            source-snapshot (interpreter/latest-snapshot rds source)
+            plan (plan/replace-tree instances source source-snapshot target
                                     :restart restart :tags tags)]
         (cond (:plan options)
               (do (println (flight-plan (interpreter/check-plan instances plan)))

--- a/src/stack_mitosis/cli.clj
+++ b/src/stack_mitosis/cli.clj
@@ -60,7 +60,7 @@
             use-restore-snapshot (or (:restore-snapshot options) (not same-vpc))
             source-snapshot (if use-restore-snapshot
                               (interpreter/latest-snapshot rds source)
-                              :none)]
+                              nil)]
 
         (when (or (not use-restore-snapshot)
                   (interpreter/verify-snapshot-exists instances [source target]

--- a/src/stack_mitosis/cli.clj
+++ b/src/stack_mitosis/cli.clj
@@ -50,10 +50,12 @@
       (log/infof "Assuming role %s" (:role-arn role))
       (sudo/sudo-provider role)))
   (let [rds (interpreter/client)
-        instances (interpreter/databases rds)]
-    (when (interpreter/verify-databases-exist instances [source target])
+        instances (interpreter/databases rds)
+        source-snapshot (interpreter/latest-snapshot rds source)]
+    (when (and (interpreter/verify-databases-exist instances [source target])
+               (interpreter/verify-snapshot-exists instances [source target]
+                                                   source-snapshot))
       (let [tags (interpreter/list-tags rds instances target)
-            source-snapshot (interpreter/latest-snapshot rds source)
             plan (plan/replace-tree instances source source-snapshot target
                                     :restart restart :tags tags)]
         (cond (:plan options)

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -54,7 +54,7 @@
 (defn verify-snapshot-exists
   [instances identifiers snapshot]
   (let [instances (map (partial lookup/by-id instances) identifiers)
-        vpcs (map #(->> % :DBSubnetGroup :VpcId) instances)
+        vpcs (map #(get-in % [:DBSubnetGroup :VpcId]) instances)
         cross-vpc-mitosis (-> vpcs distinct count (> 1))]
     (if (and cross-vpc-mitosis (not snapshot))
       (do

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -75,7 +75,7 @@
                         (op/completed? (describe rds new-id)))]
           [id #(op/completed? (describe rds id))])
         started (. System (nanoTime))
-        ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 120})
+        ret (wait/poll-until completed-fn {:delay 60000 :max-attempts 180})
         msecs (/ (double (- (. System (nanoTime)) started)) 1000000.0)
         status (-> (describe rds result-id) :DBInstances first :DBInstanceStatus)
         msg (format "Completed after %.2fs with status %s" (/ msecs 1000) status)]

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -62,6 +62,15 @@
                 [db-id (:TagList (invoke-logged! rds (op/tags arn)))])))
        (into {})))
 
+(defn latest-snapshot
+  "Returns the latest snapshot for an instance"
+  [rds target]
+  (->> (invoke-logged! rds (op/list-snapshots target))
+       (:DBSnapshots)
+       (sort-by :SnapshotCreateTime)
+       (last)
+       (:DBSnapshotIdentifier)))
+
 (defn describe
   [rds id]
   (invoke-logged! rds (op/describe id)))

--- a/src/stack_mitosis/interpreter.clj
+++ b/src/stack_mitosis/interpreter.clj
@@ -143,7 +143,7 @@
   (sudo/sudo-provider (sudo/load-role "resources/role.edn"))
   (def rds (client))
   (-> (predict/state [] (example/create example/template))
-      (plan/replace-tree "mitosis-prod" "mitosis-demo"))
+      (plan/replace-tree "mitosis-prod" "mitosis-demo" nil))
 
   (interpret rds (op/shell-command "echo restart"))
   (evaluate-plan rds [(op/shell-command "true") (op/shell-command "false")
@@ -151,7 +151,7 @@
 
   ;; check plan
   (let [state (databases rds)]
-    (check-plan state (plan/replace-tree state "mitosis-prod" "mitosis-demo")))
+    (check-plan state (plan/replace-tree state "mitosis-prod" "mitosis-demo" nil)))
 
   ;; create a copy of mitosis-prod tree
   (let [state (databases rds)]

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -190,10 +190,14 @@
   (let [attributes-to-clone ;; attributes not supported by restore-snapshot
         [:MonitoringRoleArn
          :MonitoringInterval
-         ;; :KmsKeyId ;; modify_not_supported
-         :EnhancedMonitoringResourceArn
          :PerformanceInsightsKMSKeyId
-         :PerformanceInsightsRetentionPeriod]
+         :PerformanceInsightsRetentionPeriod
+         :PreferredMaintenanceWindow
+         :PreferredBackupWindow
+         ;; TODO ?
+         ;; :AllocatedStorage ;; Tricky, only supports increase
+         ;; :MaxAllocatedStorage
+         ]
 
         translated-attributes
         {:EnablePerformanceInsights (:PerformanceInsightsEnabled original) ;; restore_not_supported
@@ -209,12 +213,7 @@
                       (and (= (:ParameterApplyStatus group) "in-sync")
                            (:DBParameterGroupName group)))))}]
     (-> original
-        (select-keys [:PreferredMaintenanceWindow
-                      :PreferredBackupWindow
-                      ;; TODO ?
-                      ;; :AllocatedStorage ;; Tricky, only supports increase
-                      ;; :MaxAllocatedStorage
-                      ])
+        (select-keys attributes-to-clone)
         ;; Attributes requiring custom rules to extract from original and
         ;; translate to key for modify-db request
         (merge (into {} (remove (fn [[_ v]] (nil-or-empty? v))

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -61,6 +61,7 @@
          :EnableIAMDatabaseAuthentication (:IAMDatabaseAuthenticationEnabled original)
          :EnableCloudwatchLogsExports (:EnabledCloudwatchLogsExports original)
          :Port (:Port (:Endpoint original))
+         :DBSubnetGroupName (:DBSubnetGroupName (:DBSubnetGroup original))
 
          ;; all active security groups ids
          :VpcSecurityGroupIds

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -33,6 +33,60 @@
       (and (or (seq? v) (vector? v))
            (empty? v))))
 
+(defn restore-snapshot-attributes
+  "Creates a list of additional attributes to clone from original instance into
+  the newly created replica instance.
+
+  https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromDBSnapshot.html
+  has more information on these attributes."
+  [original tags]
+  (let [attributes-to-clone
+        [:CopyTagsToSnapshot
+         :PubliclyAccessible
+         :AutoMinorVersionUpgrade
+         :DBInstanceClass
+         ;; :DeletionProtection ; must be false for repeated invocation
+         ;; :KmsKeyId ;; not supported by restore or modify
+         ;;              but is guaranteed to remain the same
+         ;;              it can only change when we copy a snapshot
+         ;; :SourceRegion ; not applicable?
+         :ProcessorFeatures
+         ;; :UseDefaultProcessorFeatures ; just copy features directly?
+         :Iops
+         :StorageType
+         :MultiAZ]
+
+        translated-attributes
+        {:Tags tags
+         :EnableIAMDatabaseAuthentication (:IAMDatabaseAuthenticationEnabled original)
+         :EnableCloudwatchLogsExports (:EnabledCloudwatchLogsExports original)
+         :Port (:Port (:Endpoint original))
+
+         ;; all active security groups ids
+         :VpcSecurityGroupIds
+         (->> original
+              :VpcSecurityGroups
+              (filter (fn [group] (= (:Status group) "active")))
+              (map :VpcSecurityGroupId))
+
+         ;; first synchronized option group name
+         :OptionGroupName
+         (->> original
+              :OptionGroupMemberships
+              (some (fn [group]
+                      (and (= (:Status group) "in-sync")
+                           (:OptionGroupName group)))))
+         ;; TODO map for names on original
+         ;; :DomainMemberships -> :Domain, :DomainIAMRoleName
+         }]
+    (-> original
+        ;; copy as-is with no translation
+        (select-keys attributes-to-clone)
+        ;; Attributes requiring custom rules to extract from original and
+        ;; translate to key for clone-replica request
+        (merge (into {} (remove (fn [[_ v]] (nil-or-empty? v))
+                                translated-attributes))))))
+
 (defn clone-replica-attributes
   "Creates a list of additional attributes to clone from original instance into
   the newly created replica instance.
@@ -116,6 +170,47 @@
                       :PreferredBackupWindow
                       ;; TODO ?
                       ;; :AllocatedStorage
+                      ;; :MaxAllocatedStorage
+                      ])
+        ;; Attributes requiring custom rules to extract from original and
+        ;; translate to key for modify-db request
+        (merge (into {} (remove (fn [[_ v]] (nil-or-empty? v))
+                                translated-attributes))))))
+
+(defn post-restore-snapshot-attributes
+  "List of additional attributes to apply after creation.
+
+  Some parameters are not available or applicable at time of creation, so they
+  need to be applied after.
+
+  https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html
+  has more information on these attributes."
+  [original]
+  (let [attributes-to-clone ;; attributes not supported by restore-snapshot
+        [:MonitoringRoleArn
+         :MonitoringInterval
+         :PerformanceInsightsKMSKeyId
+         ;; :KmsKeyId ;; modify_not_supported
+         :PerformanceInsightsRetentionPeriod]
+
+        translated-attributes
+        {:EnablePerformanceInsights (:PerformanceInsightsEnabled original) ;; restore_not_supported
+
+         ;; Triggers "The specified DB instance is already in the target DB subnet group"
+         ;; probably need to detect if changing? disabling for now
+         ;; :DBSubnetGroupName (:DBSubnetGroupName (:DBSubnetGroup original))
+         ;; first synchronized db parameter group name
+         :DBParameterGroupName
+         (->> original
+              :DBParameterGroups
+              (some (fn [group]
+                      (and (= (:ParameterApplyStatus group) "in-sync")
+                           (:DBParameterGroupName group)))))}]
+    (-> original
+        (select-keys [:PreferredMaintenanceWindow
+                      :PreferredBackupWindow
+                      ;; TODO ?
+                      ;; :AllocatedStorage ;; Tricky, only supports increase
                       ;; :MaxAllocatedStorage
                       ])
         ;; Attributes requiring custom rules to extract from original and

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -33,6 +33,9 @@
       (and (or (seq? v) (vector? v))
            (empty? v))))
 
+(defn same-vpc? [db-a db-b]
+  (= (-> db-a :DBSubnetGroup :VpcId) (-> db-b :DBSubnetGroup :VpcId)))
+
 (defn restore-snapshot-attributes
   "Creates a list of additional attributes to clone from original instance into
   the newly created replica instance.

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -121,7 +121,6 @@
          :EnablePerformanceInsights (:PerformanceInsightsEnabled original)
          :EnableIAMDatabaseAuthentication (:IAMDatabaseAuthenticationEnabled original)
          :EnableCloudwatchLogsExports (:EnabledCloudwatchLogsExports original)
-         :DBSubnetGroupName (:DBSubnetGroupName (:DBSubnetGroup original))
          :Port (:Port (:Endpoint original))
 
          ;; all active security groups ids

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -34,7 +34,7 @@
            (empty? v))))
 
 (defn same-vpc? [db-a db-b]
-  (= (-> db-a :DBSubnetGroup :VpcId) (-> db-b :DBSubnetGroup :VpcId)))
+  (= (get-in db-a [:DBSubnetGroup :VpcId]) (get-in db-b [:DBSubnetGroup :VpcId])))
 
 (defn restore-snapshot-attributes
   "Creates a list of additional attributes to clone from original instance into

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -190,8 +190,9 @@
   (let [attributes-to-clone ;; attributes not supported by restore-snapshot
         [:MonitoringRoleArn
          :MonitoringInterval
-         :PerformanceInsightsKMSKeyId
          ;; :KmsKeyId ;; modify_not_supported
+         :EnhancedMonitoringResourceArn
+         :PerformanceInsightsKMSKeyId
          :PerformanceInsightsRetentionPeriod]
 
         translated-attributes

--- a/src/stack_mitosis/lookup.clj
+++ b/src/stack_mitosis/lookup.clj
@@ -121,6 +121,7 @@
          :EnablePerformanceInsights (:PerformanceInsightsEnabled original)
          :EnableIAMDatabaseAuthentication (:IAMDatabaseAuthenticationEnabled original)
          :EnableCloudwatchLogsExports (:EnabledCloudwatchLogsExports original)
+         :DBSubnetGroupName (:DBSubnetGroupName (:DBSubnetGroup original))
          :Port (:Port (:Endpoint original))
 
          ;; all active security groups ids

--- a/src/stack_mitosis/operations.clj
+++ b/src/stack_mitosis/operations.clj
@@ -45,7 +45,7 @@
     :request (merge attributes
                     {:DBSnapshotIdentifier snapshot-id
                      :DBInstanceIdentifier target})
-    :meta {:SourceDBInstanceIdentifier source}}))
+    :meta {:SourceDBInstance source}}))
 
 (defn list-snapshots
   ([target]

--- a/src/stack_mitosis/operations.clj
+++ b/src/stack_mitosis/operations.clj
@@ -38,6 +38,11 @@
                     {:SourceDBInstanceIdentifier source
                      :DBInstanceIdentifier replica})}))
 
+(defn list-snapshots
+  ([target]
+   {:op :DescribeDBSnapshots
+    :request {:DBInstanceIdentifier target}}))
+
 (defn promote
   [id]
   {:op :PromoteReadReplica

--- a/src/stack_mitosis/operations.clj
+++ b/src/stack_mitosis/operations.clj
@@ -82,7 +82,7 @@
 (defn blocking-operation?
   [action]
   (contains? #{:CreateDBInstance :CreateDBInstanceReadReplica
-               :PromoteReadReplica :ModifyDBInstance} (:op action)))
+               :PromoteReadReplica :ModifyDBInstance :RestoreDBInstanceFromDBSnapshot} (:op action)))
 
 (defn transition-to
   "Maps current rds status to in-progress, failed or done

--- a/src/stack_mitosis/operations.clj
+++ b/src/stack_mitosis/operations.clj
@@ -38,6 +38,15 @@
                     {:SourceDBInstanceIdentifier source
                      :DBInstanceIdentifier replica})}))
 
+(defn restore-snapshot
+  ([snapshot-id source target] (restore-snapshot snapshot-id source target {}))
+  ([snapshot-id source target attributes]
+   {:op :RestoreDBInstanceFromDBSnapshot
+    :request (merge attributes
+                    {:DBSnapshotIdentifier snapshot-id
+                     :DBInstanceIdentifier target})
+    :meta {:SourceDBInstanceIdentifier source}}))
+
 (defn list-snapshots
   ([target]
    {:op :DescribeDBSnapshots

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -31,7 +31,7 @@
 ;; postgres does not allow replica of replica, so need to promote before
 ;; replicating children
 (defn copy-tree
-  [instances source target alias-fn & {:keys [tags]}]
+  [instances source source-snapshot target alias-fn & {:keys [tags]}]
   (let [alias-tags
         (->> tags
              (map (fn [[db-id instance-tags]] [(alias-fn db-id) instance-tags]))
@@ -72,12 +72,12 @@
        (map op/delete)))
 
 (defn replace-tree
-  [instances source target & {:keys [restart tags] :or {tags {}}}]
+  [instances source source-snapshot target & {:keys [restart tags] :or {tags {}}}]
   ;; actions in copy, rename & delete change the local instances db, so use
   ;; predict to update that db for calculating next set of operations by
   ;; applying computation thus far to the initial instances
   ;; TODO something something sequence monad
-  (let [copy (copy-tree instances source target
+  (let [copy (copy-tree instances source source-snapshot target
                         (partial aliased "temp")
                         :tags tags)
 

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -28,8 +28,6 @@
        (zipmap ids)
        topological-sort))
 
-;; postgres does not allow replica of replica, so need to promote before
-;; replicating children
 (defn copy-tree
   [instances source source-snapshot target alias-fn & {:keys [tags]}]
   (let [alias-tags
@@ -48,6 +46,8 @@
         root-restore-attrs (lookup/restore-snapshot-attributes root (get alias-tags root-id))]
     (into (if same-vpc
             [(op/create-replica source root-id root-attrs)
+             ;; postgres does not allow replica of replica, so need to promote before
+             ;; replicating children
              (op/promote root-id)
              ;; postgres only allows backups after promotion
              (op/enable-backups root-id (lookup/post-create-replica-attributes root))]

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -39,7 +39,6 @@
                            (list-tree instances target))
         root-id (:DBInstanceIdentifier root)
 
-        ;; can't rely on replication when target and source have different VPCs
         source-instance (lookup/by-id instances source)
         same-vpc (lookup/same-vpc? source-instance root)
         root-attrs (lookup/clone-replica-attributes root (get alias-tags root-id))

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -124,6 +124,9 @@
     (and (= op :CreateDBInstanceReadReplica)
          (lookup/by-id instances (r/db-id action)))
     [:skip (duplicate-instance (r/db-id action))]
+    (and (= op :RestoreDBInstanceFromDBSnapshot)
+         (lookup/by-id instances (r/db-id action)))
+    [:skip (duplicate-instance (r/db-id action))]
     (and (= op :PromoteReadReplica)
          (not (:ReadReplicaSourceDBInstanceIdentifier (lookup/by-id instances (r/db-id action)))))
     [:skip (promoted-instance (r/db-id action))]

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -42,11 +42,8 @@
         root-id (:DBInstanceIdentifier root)
 
         ;; can't rely on replication when target and source have different VPCs
-        target-vpc (->> root :DBSubnetGroup :VpcId)
         source-instance (lookup/by-id instances source)
-        source-vpc (->> source-instance :DBSubnetGroup :VpcId)
-        same-vpc (= source-vpc target-vpc)
-
+        same-vpc (lookup/same-vpc? source-instance root)
         root-attrs (lookup/clone-replica-attributes root (get alias-tags root-id))
         root-restore-attrs (lookup/restore-snapshot-attributes root (get alias-tags root-id))]
     (into (if same-vpc

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -40,10 +40,9 @@
         root-id (:DBInstanceIdentifier root)
 
         source-instance (lookup/by-id instances source)
-        same-vpc (lookup/same-vpc? source-instance root)
         root-attrs (lookup/clone-replica-attributes root (get alias-tags root-id))
         root-restore-attrs (lookup/restore-snapshot-attributes root (get alias-tags root-id))]
-    (into (if same-vpc
+    (into (if (= source-snapshot :none)
             [(op/create-replica source root-id root-attrs)
              ;; postgres does not allow replica of replica, so need to promote before
              ;; replicating children

--- a/src/stack_mitosis/planner.clj
+++ b/src/stack_mitosis/planner.clj
@@ -42,7 +42,7 @@
         source-instance (lookup/by-id instances source)
         root-attrs (lookup/clone-replica-attributes root (get alias-tags root-id))
         root-restore-attrs (lookup/restore-snapshot-attributes root (get alias-tags root-id))]
-    (into (if (= source-snapshot :none)
+    (into (if (nil? source-snapshot)
             [(op/create-replica source root-id root-attrs)
              ;; postgres does not allow replica of replica, so need to promote before
              ;; replicating children

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -40,9 +40,9 @@
   [instances action]
   ;; For create replica, use the ARN from the source database
   (let [snapshot-id (->> action :request :DBSnapshotIdentifier)
-        source-arn (->> action dbg :meta :SourceDBInstance :DBInstanceArn)
+        source-arn (->> action :meta :SourceDBInstance :DBInstanceArn)
         snapshot-arn (-> source-arn (str/split #":db:") first (str ":snapshot:" snapshot-id))
-        db-id (dbg (r/db-id action))
+        db-id (r/db-id action)
         target-arn (:DBInstanceArn (lookup/by-id (predict/predict instances action) db-id))]
     [{:op (:op action)
       ;; TODO: can these permissions be more specific instead of wildcard?

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -39,9 +39,8 @@
 (defmethod permissions :RestoreDBInstanceFromDBSnapshot
   [instances action]
   ;; For create replica, use the ARN from the source database
-  (let [snapshot-id (->> action :request :DBSnapshotIdentifier)
-        source-arn (->> action :meta :SourceDBInstance :DBInstanceArn)
-        snapshot-arn (-> source-arn (str/split #":db:") first (str ":snapshot:" snapshot-id))
+  (let [source-arn (->> action :meta :SourceDBInstance :DBInstanceArn)
+        snapshot-arn (-> source-arn (str/split #":db:") first (str ":snapshot:*"))
         db-id (r/db-id action)
         target-arn (:DBInstanceArn (lookup/by-id (predict/predict instances action) db-id))]
     [{:op (:op action)

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -98,7 +98,7 @@
          [(make-arn "mitosis-*")]))
 
 (defn globals []
-  (allow [:DescribeDBInstances :ListTagsForResource]
+  (allow [:DescribeDBInstances :ListTagsForResource :DescribeDBSnapshots]
          [(make-arn "*")]))
 
 ;; TODO breakup permissions per operation type with better granularity

--- a/src/stack_mitosis/policy.clj
+++ b/src/stack_mitosis/policy.clj
@@ -51,7 +51,8 @@
                   (make-arn "*" :type "pg")
                   (make-arn "*" :type "subgrp")]
                  [snapshot-arn target-arn])}
-     {:op :AddTagsToResource :arn target-arn}]))
+     {:op :AddTagsToResource :arn target-arn}
+     {:op :DescribeDBSnapshots :arn "*"}]))
 
 (defmethod permissions :ModifyDBInstance
   [instances action]
@@ -97,7 +98,7 @@
          [(make-arn "mitosis-*")]))
 
 (defn globals []
-  (allow [:DescribeDBInstances :ListTagsForResource :DescribeDBSnapshots]
+  (allow [:DescribeDBInstances :ListTagsForResource]
          [(make-arn "*")]))
 
 ;; TODO breakup permissions per operation type with better granularity

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -95,6 +95,7 @@
       ;; default values from RDS.
       (merge source-db $)
       (assoc $ :DBInstanceArn target-arn)
+      (dissoc $ :ReadReplicaDBInstanceIdentifiers)
       (conj instances $))))
 
 (defmethod predict :ModifyDBInstance

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -79,8 +79,8 @@
 
 (defmethod predict :RestoreDBInstanceFromDBSnapshot
   [instances op]
-  {:post [(lookup/exists? % (r/db-id op))]}
-  (let [source-id (->> op :meta :SourceDBInstanceIdentifier)
+  {:pre [(->> op :meta :SourceDBInstance :DBInstanceIdentifier (lookup/exists? instances))]
+   :post [(lookup/exists? % (r/db-id op))]}
   (let [source-id (->> op :meta :SourceDBInstance :DBInstanceIdentifier)
         source-db (lookup/by-id instances source-id)]
     (->> op

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -87,7 +87,7 @@
         ;; end up being the source-arn
         target-arn (-> source-db :DBInstanceArn (str/split #":db:") first (str ":db:" target-id))]
     (as-> op $
-      ($ :request)
+      (:request $)
       (dissoc $ :DBSnapshotIdentifier)
       ;; This is not reeeally what happens, but replicating what happens is
       ;; complicated. We're getting a DB in the new subnet, missing a few

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -77,6 +77,17 @@
             (update (lookup/position instances parent) detach child)
             (update (lookup/position instances child) promote))))))
 
+(defmethod predict :RestoreDBInstanceFromDBSnapshot
+  [instances op]
+  {:post [(lookup/exists? % (r/db-id op))]}
+  (let [source-id (->> op :meta :SourceDBInstanceIdentifier)
+        source-db (lookup/by-id instances source-id)]
+    (->> op
+         (:request)
+         (#(dissoc %2 %1) :DBSnapshotIdentifier)
+         (merge source-db)
+         (conj instances))))
+
 (defmethod predict :ModifyDBInstance
   [instances op]
   {:pre [(lookup/exists? instances (r/db-id op))]}

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -79,8 +79,7 @@
 
 (defmethod predict :RestoreDBInstanceFromDBSnapshot
   [instances op]
-  {:pre [(->> op :meta :SourceDBInstance :DBInstanceIdentifier (lookup/exists? instances))]
-   :post [(lookup/exists? % (r/db-id op))]}
+  {:post [(lookup/exists? % (r/db-id op))]}
   (let [source-id (->> op :meta :SourceDBInstance :DBInstanceIdentifier)
         source-db (lookup/by-id instances source-id)]
     (->> op

--- a/src/stack_mitosis/predict.clj
+++ b/src/stack_mitosis/predict.clj
@@ -81,6 +81,7 @@
   [instances op]
   {:post [(lookup/exists? % (r/db-id op))]}
   (let [source-id (->> op :meta :SourceDBInstanceIdentifier)
+  (let [source-id (->> op :meta :SourceDBInstance :DBInstanceIdentifier)
         source-db (lookup/by-id instances source-id)]
     (->> op
          (:request)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,30 @@
+# Test environment Terraform code
+
+This terraform code creates a test environment for all invariants of `stack-mitosis`:
+
+- MySQL
+  - Same VPC
+  - Different VPC
+- Postgres
+  - Same VPC
+  - Different VPC
+
+## How to use
+
+```
+$ terraform apply
+```
+
+Wait some 15 minutes.
+
+See the output:
+
+```
+
+```
+
+Run stack-mitosis against all pairs of source and target instances:
+
+```
+
+```

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,20 +11,19 @@ This terraform code creates a test environment for all invariants of `stack-mito
 
 ## How to use
 
-```
-$ terraform apply
-```
+    $ terraform apply
 
 Wait some 15 minutes.
 
-See the output:
+Terraform output:
 
-```
+    Apply complete! Resources: 17 added, 0 changed, 0 destroyed.
 
-```
+    Outputs:
 
-Run stack-mitosis against all pairs of source and target instances:
+    test_commands = clj -m stack-mitosis.cli --source mitosis-mysql-src --target mitosis-mysql-target-different-vpc
+    clj -m stack-mitosis.cli --source mitosis-mysql-src --target mitosis-mysql-target-same-vpc
+    clj -m stack-mitosis.cli --source mitosis-postgres-src --target mitosis-postgres-target-different-vpc
+    clj -m stack-mitosis.cli --source mitosis-postgres-src --target mitosis-postgres-target-same-vpc
 
-```
-
-```
+Run the test commands in the terraform output to validate stack-mitosis against all pairs of source and target instances.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,142 @@
+terraform {
+  required_version = "~> 0.13.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+locals {
+  source = {
+    port                    = 5430
+    backup_retention_period = 1
+    backup_window           = "05:30-06:20"
+    maintenance_window      = "tue:07:02-tue:08:00"
+  }
+  target = {
+    port               = 5431
+    backup_retention_period = 1
+    backup_window           = "05:20-06:20"
+    maintenance_window = "mon:07:30-mon:08:00"
+  }
+
+  mysql       = { engine = "mysql" }
+  postgres    = { engine = "postgres" }
+  vpc_a = { db_subnet_group_name = null }
+  vpc_b     = { db_subnet_group_name = aws_db_subnet_group.main.name }
+
+  sources = {
+    mitosis-mysql-src                     = merge(local.source, local.mysql, local.vpc_a),
+    mitosis-postgres-src                  = merge(local.source, local.postgres, local.vpc_a),
+  }
+  targets = {
+    mitosis-mysql-target-same-vpc         = merge(local.target, local.mysql, local.vpc_a),
+    mitosis-mysql-target-different-vpc    = merge(local.target, local.mysql, local.vpc_b),
+    mitosis-postgres-target-same-vpc      = merge(local.target, local.postgres, local.vpc_a),
+    mitosis-postgres-target-different-vpc = merge(local.target, local.postgres, local.vpc_b),
+  }
+  dbs = merge(local.sources, local.targets)
+}
+
+# Configure the AWS Provider
+provider "aws" {
+  # Or whatever region you want
+  region = "us-west-2"
+}
+
+# Current region
+data "aws_region" "current" {}
+
+# Create a VPC
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name    = "stack-mitosis"
+    Service = "Mitosis"
+    Env     = "test"
+  }
+}
+
+# Create two subnets so we can create a subnet group
+resource "aws_subnet" "a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.0.0/24"
+  availability_zone = "${data.aws_region.current.name}a"
+
+  tags = {
+    Name    = "Mitosis A"
+    Service = "Mitosis"
+    Env     = "test"
+  }
+}
+
+resource "aws_subnet" "b" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = "10.0.1.0/24"
+  availability_zone = "${data.aws_region.current.name}b"
+
+  tags = {
+    Name    = "Mitosis B"
+    Service = "Mitosis"
+    Env     = "test"
+  }
+}
+
+# Subnet group for our databases
+resource "aws_db_subnet_group" "main" {
+  name       = "mitosis-test"
+  subnet_ids = [aws_subnet.a.id, aws_subnet.b.id]
+
+  tags = {
+    Name    = "Mitosis"
+    Service = "Mitosis"
+    Env     = "test"
+  }
+}
+
+# Random password generator for the required field `password` on the DBs
+resource "random_password" "password" {
+  length           = 16
+  special          = false
+}
+
+# Create our databases
+resource "aws_db_instance" "main" {
+  for_each            = local.dbs
+  allocated_storage   = 10
+  instance_class      = "db.t3.micro"
+  username            = "foo"
+  skip_final_snapshot = true
+
+  password = random_password.password.result
+
+  identifier              = each.key
+  engine                  = each.value.engine
+  db_subnet_group_name    = each.value.db_subnet_group_name
+  backup_retention_period = each.value.backup_retention_period
+  backup_window           = each.value.backup_window
+  maintenance_window      = each.value.maintenance_window
+  port                    = each.value.port
+
+  tags = {
+    Service = "Mitosis"
+    Env     = "test"
+  }
+}
+
+# And their replicas
+resource "aws_db_instance" "replica" {
+  for_each             = aws_db_instance.main
+  identifier           = "${each.value.id}-replica"
+  replicate_source_db  = each.value.id
+  engine               = each.value.engine
+  instance_class       = "db.t3.micro"
+  skip_final_snapshot  = true
+
+  tags = {
+    Service = "Mitosis"
+    Env     = "test"
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,11 @@
+locals {
+  commands = flatten([for src in keys(local.sources): 
+    [for target in keys(local.targets): 
+      "clj -m stack-mitosis.cli --source ${src} --target ${target}"
+      if aws_db_instance.main[src].engine == aws_db_instance.main[target].engine
+    ]
+  ])
+}
+output "test_commands" {
+  value = join("\n",local.commands)
+}

--- a/test/stack_mitosis/lookup_test.clj
+++ b/test/stack_mitosis/lookup_test.clj
@@ -55,3 +55,7 @@
             ;; :DBSubnetGroupName "subnet-group"
             }
            (lookup/post-create-replica-attributes instance)))))
+
+(deftest same-vpc?
+  (is (= true (lookup/same-vpc? {:DBSubnetGroup {:VpcId "a"}} {:DBSubnetGroup {:VpcId "a"}})))
+  (is (= false (lookup/same-vpc? {:DBSubnetGroup {:VpcId "a"}} {:DBSubnetGroup {:VpcId "b"}}))))

--- a/test/stack_mitosis/planner_test.clj
+++ b/test/stack_mitosis/planner_test.clj
@@ -126,6 +126,7 @@
             "production" snapshot-id "staging")))
 
     (is (= [(op/restore-snapshot snapshot-id {:DBInstanceIdentifier "production"
+                                              :DBInstanceArn "arn:db:production"
                                               :PreferredMaintenanceWindow "tue:01:00-tue:02:00"
                                               :DBSubnetGroup {:VpcId "v1"}} "temp-staging")
             (op/enable-backups "temp-staging"
@@ -140,7 +141,7 @@
             (op/delete "old-staging-replica")
             (op/delete "old-staging")]
            (plan/replace-tree
-            [{:DBInstanceIdentifier "production"
+            [{:DBInstanceIdentifier "production" :DBInstanceArn "arn:db:production"
               :PreferredMaintenanceWindow "tue:01:00-tue:02:00" :DBSubnetGroup {:VpcId "v1"}}
              {:DBInstanceIdentifier "staging" :ReadReplicaDBInstanceIdentifiers ["staging-replica"]
               :PreferredMaintenanceWindow "tue:02:00-tue:03:00" :MonitoringInterval 60}

--- a/test/stack_mitosis/planner_test.clj
+++ b/test/stack_mitosis/planner_test.clj
@@ -117,7 +117,9 @@
             (op/delete "old-staging-replica")
             (op/delete "old-staging")]
            (plan/replace-tree
-            [{:DBInstanceIdentifier "production"
+            [{:DBInstanceIdentifier "production" :ReadReplicaDBInstanceIdentifiers ["production-replica"]
+              :PreferredMaintenanceWindow "tue:01:00-tue:02:00"}
+             {:DBInstanceIdentifier "production-replica" :ReadReplicaSourceDBInstanceIdentifier "production"
               :PreferredMaintenanceWindow "tue:01:00-tue:02:00"}
              {:DBInstanceIdentifier "staging" :ReadReplicaDBInstanceIdentifiers ["staging-replica"]
               :PreferredMaintenanceWindow "tue:02:00-tue:03:00"}
@@ -128,6 +130,7 @@
     (is (= [(op/restore-snapshot snapshot-id {:DBInstanceIdentifier "production"
                                               :DBInstanceArn "arn:db:production"
                                               :PreferredMaintenanceWindow "tue:01:00-tue:02:00"
+                                              :ReadReplicaDBInstanceIdentifiers ["production-replica"]
                                               :DBSubnetGroup {:VpcId "v1"}} "temp-staging")
             (op/enable-backups "temp-staging"
                                {:PreferredMaintenanceWindow "tue:02:00-tue:03:00" :MonitoringInterval 60})
@@ -142,6 +145,9 @@
             (op/delete "old-staging")]
            (plan/replace-tree
             [{:DBInstanceIdentifier "production" :DBInstanceArn "arn:db:production"
+              :ReadReplicaDBInstanceIdentifiers ["production-replica"]
+              :PreferredMaintenanceWindow "tue:01:00-tue:02:00" :DBSubnetGroup {:VpcId "v1"}}
+             {:DBInstanceIdentifier "production-replica" :ReadReplicaSourceDBInstanceIdentifier "production"
               :PreferredMaintenanceWindow "tue:01:00-tue:02:00" :DBSubnetGroup {:VpcId "v1"}}
              {:DBInstanceIdentifier "staging" :ReadReplicaDBInstanceIdentifiers ["staging-replica"]
               :PreferredMaintenanceWindow "tue:02:00-tue:03:00" :MonitoringInterval 60}

--- a/test/stack_mitosis/planner_test.clj
+++ b/test/stack_mitosis/planner_test.clj
@@ -40,7 +40,7 @@
             (op/modify "temp-b" {})
             (op/create-replica "temp-b" "temp-c")
             (op/modify "temp-c" {})]
-           (plan/copy-tree instances "source" snapshot-id "target"
+           (plan/copy-tree instances "source" :none "target"
                            (partial plan/aliased "temp")
                            :tags {"target" tags-target
                                   "b" tags-b})))
@@ -101,7 +101,7 @@
             (op/rename "temp-staging" "staging")
             (op/delete "old-staging-replica")
             (op/delete "old-staging")]
-           (plan/replace-tree instances "production" snapshot-id "staging")))
+           (plan/replace-tree instances "production" :none "staging")))
 
     (is (= [(op/create-replica "production" "temp-staging")
             (op/promote "temp-staging")
@@ -123,7 +123,7 @@
               :PreferredMaintenanceWindow "tue:02:00-tue:03:00"}
              {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
               :PreferredMaintenanceWindow "tue:03:00-tue:04:00"}]
-            "production" snapshot-id "staging")))
+            "production" :none "staging")))
 
     (is (= [(op/restore-snapshot snapshot-id {:DBInstanceIdentifier "production"
                                               :DBInstanceArn "arn:db:production"
@@ -161,7 +161,7 @@
             (op/shell-command "./restart.sh")
             (op/delete "old-staging-replica")
             (op/delete "old-staging")]
-           (plan/replace-tree instances "production" snapshot-id "staging"
+           (plan/replace-tree instances "production" :none "staging"
                               :restart "./restart.sh"
                               :tags {"staging" tags
                                      "staging-replica" tags})))))

--- a/test/stack_mitosis/planner_test.clj
+++ b/test/stack_mitosis/planner_test.clj
@@ -40,7 +40,7 @@
             (op/modify "temp-b" {})
             (op/create-replica "temp-b" "temp-c")
             (op/modify "temp-c" {})]
-           (plan/copy-tree instances "source" :none "target"
+           (plan/copy-tree instances "source" nil "target"
                            (partial plan/aliased "temp")
                            :tags {"target" tags-target
                                   "b" tags-b})))
@@ -101,7 +101,7 @@
             (op/rename "temp-staging" "staging")
             (op/delete "old-staging-replica")
             (op/delete "old-staging")]
-           (plan/replace-tree instances "production" :none "staging")))
+           (plan/replace-tree instances "production" nil "staging")))
 
     (is (= [(op/create-replica "production" "temp-staging")
             (op/promote "temp-staging")
@@ -125,7 +125,7 @@
               :PreferredMaintenanceWindow "tue:02:00-tue:03:00"}
              {:DBInstanceIdentifier "staging-replica" :ReadReplicaSourceDBInstanceIdentifier "staging"
               :PreferredMaintenanceWindow "tue:03:00-tue:04:00"}]
-            "production" :none "staging")))
+            "production" nil "staging")))
 
     (is (= [(op/restore-snapshot snapshot-id {:DBInstanceIdentifier "production"
                                               :DBInstanceArn "arn:db:production"
@@ -167,7 +167,7 @@
             (op/shell-command "./restart.sh")
             (op/delete "old-staging-replica")
             (op/delete "old-staging")]
-           (plan/replace-tree instances "production" :none "staging"
+           (plan/replace-tree instances "production" nil "staging"
                               :restart "./restart.sh"
                               :tags {"staging" tags
                                      "staging-replica" tags})))))

--- a/test/stack_mitosis/planner_test.clj
+++ b/test/stack_mitosis/planner_test.clj
@@ -174,6 +174,8 @@
            (plan/attempt instances (op/create {:DBInstanceIdentifier "a"}))))
     (is (= [:skip (plan/duplicate-instance "b")]
            (plan/attempt instances (op/create-replica "a" "b"))))
+    (is (= [:skip (plan/duplicate-instance "b")]
+           (plan/attempt instances (op/restore-snapshot "c" "a" "b"))))
 
     (is (= [:skip (plan/promoted-instance "a")]
            (plan/attempt instances (op/promote "a"))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -47,6 +47,15 @@
             {:op :AddTagsToResource
              :arn "arn:aws:rds:us-east-1:1234567:db:bar"}]
            (sut/permissions [instance] (op/create-replica "foo" "bar"))))
+    (is (= [{:op :RestoreDBInstanceFromDBSnapshot
+             :arn ["arn:aws:rds:*:*:og:*"
+                   "arn:aws:rds:*:*:pg:*"
+                   "arn:aws:rds:*:*:subgrp:*"
+                   "arn:aws:rds:us-east-1:1234567:snapshot:foo"
+                   "arn:aws:rds:us-east-1:1234567:db:bar"]}
+            {:op :AddTagsToResource
+             :arn "arn:aws:rds:us-east-1:1234567:db:bar"}]
+           (sut/permissions [instance] (op/restore-snapshot "foo" instance "bar"))))
     (is (= [{:op :ModifyDBInstance
              :arn ["arn:aws:rds:*:*:og:*"
                    "arn:aws:rds:*:*:pg:*"

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -80,7 +80,7 @@
 (deftest from-plan
   (is (= {:Version "2012-10-17"
           :Statement
-          [(sut/allow [:DescribeDBInstances :ListTagsForResource]
+          [(sut/allow [:DescribeDBInstances :ListTagsForResource :DescribeDBSnapshots]
                       ["arn:aws:rds:*:*:db:*"])
            (sut/allow [:CreateDBInstanceReadReplica]
                       (into ["arn:aws:rds:*:*:og:*"

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -95,4 +95,4 @@
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
          (sut/from-plan (example-instances)
-                        (plan/replace-tree (example-instances) "production" "staging")))))
+                        (plan/replace-tree (example-instances) "production" "snapshot-id" "staging")))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -51,7 +51,7 @@
              :arn ["arn:aws:rds:*:*:og:*"
                    "arn:aws:rds:*:*:pg:*"
                    "arn:aws:rds:*:*:subgrp:*"
-                   "arn:aws:rds:us-east-1:1234567:snapshot:foo"
+                   "arn:aws:rds:us-east-1:1234567:snapshot:*"
                    "arn:aws:rds:us-east-1:1234567:db:bar"]}
             {:op :AddTagsToResource
              :arn "arn:aws:rds:us-east-1:1234567:db:bar"}]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -108,7 +108,7 @@
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
          (sut/from-plan (example-instances)
-                        (plan/replace-tree (example-instances) "production" :none "staging"))))
+                        (plan/replace-tree (example-instances) "production" nil "staging"))))
   (is (= {:Version "2012-10-17"
           :Statement
           [(sut/allow [:DescribeDBInstances :ListTagsForResource]

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -54,7 +54,8 @@
                    "arn:aws:rds:us-east-1:1234567:snapshot:*"
                    "arn:aws:rds:us-east-1:1234567:db:bar"]}
             {:op :AddTagsToResource
-             :arn "arn:aws:rds:us-east-1:1234567:db:bar"}]
+             :arn "arn:aws:rds:us-east-1:1234567:db:bar"}
+            {:op :DescribeDBSnapshots :arn "*"}]
            (sut/permissions [instance] (op/restore-snapshot "foo" instance "bar"))))
     (is (= [{:op :ModifyDBInstance
              :arn ["arn:aws:rds:*:*:og:*"
@@ -80,7 +81,7 @@
 (deftest from-plan
   (is (= {:Version "2012-10-17"
           :Statement
-          [(sut/allow [:DescribeDBInstances :ListTagsForResource :DescribeDBSnapshots]
+          [(sut/allow [:DescribeDBInstances :ListTagsForResource]
                       ["arn:aws:rds:*:*:db:*"])
            (sut/allow [:CreateDBInstanceReadReplica]
                       (into ["arn:aws:rds:*:*:og:*"

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -7,6 +7,9 @@
 (defn fake-arn [name]
   (str "arn:aws:rds:us-east-1:1234567:db:" name))
 
+(defn fake-snapshot-arn [name]
+  (str "arn:aws:rds:us-east-1:1234567:snapshot:" name))
+
 (defn example-instances []
   [{:DBInstanceIdentifier "production" :ReadReplicaDBInstanceIdentifiers ["production-replica"]
     :DBInstanceArn (fake-arn "production")}
@@ -105,4 +108,36 @@
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
          (sut/from-plan (example-instances)
-                        (plan/replace-tree (example-instances) "production" "snapshot-id" "staging")))))
+                        (plan/replace-tree (example-instances) "production" :none "staging"))))
+  (is (= {:Version "2012-10-17"
+          :Statement
+          [(sut/allow [:DescribeDBInstances :ListTagsForResource]
+                      ["arn:aws:rds:*:*:db:*"])
+           (sut/allow [:RestoreDBInstanceFromDBSnapshot]
+                      ["arn:aws:rds:*:*:og:*"
+                       "arn:aws:rds:*:*:pg:*"
+                       "arn:aws:rds:*:*:subgrp:*"
+                       (fake-snapshot-arn "*")
+                       (fake-arn "temp-staging")])
+           (sut/allow [:AddTagsToResource]
+                      (mapv fake-arn ["temp-staging" "temp-staging-replica"]))
+           (sut/allow [:DescribeDBSnapshots] ["*"])
+           (sut/allow [:ModifyDBInstance]
+                      (into ["arn:aws:rds:*:*:og:*"
+                             "arn:aws:rds:*:*:pg:*"
+                             "arn:aws:rds:*:*:secgrp:*"
+                             "arn:aws:rds:*:*:subgrp:*"]
+                            (mapv fake-arn ["temp-staging" "temp-staging-replica"
+                                            "staging-replica" "old-staging-replica"
+                                            "staging" "old-staging"])))
+           (sut/allow [:RebootDBInstance]
+                      (mapv fake-arn ["temp-staging" "temp-staging-replica" "staging-replica" "staging"]))
+           (sut/allow [:CreateDBInstanceReadReplica]
+                      (into ["arn:aws:rds:*:*:og:*"
+                             "arn:aws:rds:*:*:pg:*"
+                             "arn:aws:rds:*:*:subgrp:*"]
+                            (mapv fake-arn ["temp-staging" "temp-staging-replica"])))
+           (sut/allow [:DeleteDBInstance]
+                      (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
+         (sut/from-plan (example-instances)
+                        (dbg (plan/replace-tree (example-instances) "production" "snapshot-id" "staging"))))))

--- a/test/stack_mitosis/policy_test.clj
+++ b/test/stack_mitosis/policy_test.clj
@@ -140,4 +140,4 @@
            (sut/allow [:DeleteDBInstance]
                       (mapv fake-arn ["old-staging-replica" "old-staging"]))]}
          (sut/from-plan (example-instances)
-                        (dbg (plan/replace-tree (example-instances) "production" "snapshot-id" "staging"))))))
+                        (plan/replace-tree (example-instances) "production" "snapshot-id" "staging")))))


### PR DESCRIPTION
Hi Charles!

I've adapted `stack-mitosis` to support cross-vpc cloning.

### Restore instead of create-replica

I had to use `RestoreDBInstanceFromDBSnapshot`, as RDS won't let us create cross-vpc replicas.

`RestoreDBInstanceFromDBSnapshot` gives us less configuration over the final created instance, requiring more changes to go into `ModifyDBInstance`, but also saves us a `PromoteReadReplica` step.

It also drifts from `instances` being the full state of the world. It's a bit less nice than `CreateDBInstanceReadReplica` in this way.

### Implicit switch between create-replica and restore-snapshot

I made `stack-mitosis` take the same params on both same-vpc and cross-vpc scenarios, using `RestoreDBInstanceFromDBSnapshot` only for the cross-vpc case.

I also made it assume we'll want the latest available snapshot for the `source` database. For us, with daily backups, the time since latest backup is an acceptable drift when cloning. For some it might not be. I opted to keep the tool simple.

### Restore is faster

I timed `stack-mitosis` on an empty 10GB PG DB with no replicas using both methods:

- Same VPC (22min27s)
  - `CreateDBInstanceReadReplica`: Completed after 672.65s with status available
  - `PromoteReadReplica`: Completed after 305.95s with status available
  - `ModifyDBInstance`: Completed after 122.51s with status available
  - `ModifyDBInstance`: Completed after 122.94s with status available (mitosis-staging -> mitosis-staging-old)
  - `ModifyDBInstance`: Completed after 123.28s with status available (temp-mitosis-staging -> mitosis-staging)
  - `DeleteDBInstance`: No wait

- Cross-VPC (16min14s)
  - `RestoreDBInstanceFromDBSnapshot`: Completed after 486.88s with status available
  - `ModifyDBInstance`: Completed after 182.41s with status available
  - `ModifyDBInstance`: Completed after 182.90s with status available
  - `ModifyDBInstance`: Completed after 122.17s with status available
  - `DeleteDBInstance`: No wait

Which makes me think there's a benefit to always using `RestoreDBInstanceFromDBSnapshot` for cloning primaries. I'm game making that change if you don't mind the drawbacks I listed before.

### Other stuff

- I bundled a change bumping the timeout to 3h bc RDS has been acting up lately and we're seeing 2h30min clone times for prod sometimes
- Kaocha didn't work on macOS with the recent change in `master`, I had to revert back to `clojure -A:kaocha`. It works OK on our CI, so I didn't change it in the PR. Might be something with my Clojure too, as I got it from nix.
- I don't know what you use for formatting, I used `cljfmt` and it got me some diffs. Hope my changes didn't deviate too much from standard.
- These were my first lines of Clojure :S
- Kebab-case is cool